### PR TITLE
Add prek pre-commit hooks

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,22 @@
+# Configuration file for `prek`, a git hook framework written in Rust.
+# See https://prek.j178.dev for more information.
+#:schema https://www.schemastore.org/prek.json
+
+[[repos]]
+repo = "builtin"
+hooks = [
+    { id = "trailing-whitespace" },
+    { id = "end-of-file-fixer" },
+    { id = "check-added-large-files", args = ["--maxkb=500"] },
+    { id = "check-merge-conflict" },
+
+]
+
+[[repos]]
+repo = "https://github.com/TekWizely/pre-commit-golang"
+rev = "v1.0.0-rc.1"
+hooks = [
+    { id = "go-fmt-repo" },
+    { id = "go-vet-repo-mod" },
+    { id = "go-build-repo-mod" },
+]


### PR DESCRIPTION
## Summary
- Adds `prek.toml` configuring pre-commit hooks via [prek](https://prek.j178.dev/) (Rust-based pre-commit alternative)
- Builtin hooks: trailing whitespace, end-of-file fixer, large file check (500KB), merge conflict markers
- Go hooks (via TekWizely/pre-commit-golang): `go-fmt-repo`, `go-vet-repo-mod`, `go-build-repo-mod`

## Setup
```bash
brew install prek   # if not already installed
prek install        # activate git hooks locally
```

## Test plan
- [x] `prek run --all-files` passes (Go hooks skip on main since no `.go` files yet — expected)
- [x] Hooks fire on commit (verified via commit of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)