### PR TITLE
Add manual evidence form with templates

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -376,7 +376,12 @@ async function submitEvidence(andAnother) {
       feedback.innerHTML = `<p class="feedback-ok">Created <code>${data.id}</code></p>`;
       form.querySelector('[name="result"]:checked').checked = false;
       form.notes.value = "";
-      document.getElementById("custom-fields-list").innerHTML = "";
+      const currentTpl = document.getElementById("template-select").value;
+      if (currentTpl) {
+        applyTemplate(currentTpl);
+      } else {
+        document.getElementById("custom-fields-list").innerHTML = "";
+      }
     } else {
       feedback.innerHTML = `<p class="feedback-ok">Created <code>${data.id}</code> &mdash; switching to search...</p>`;
       setTimeout(() => {
@@ -430,10 +435,312 @@ document.getElementById("add-another").addEventListener("click", () => {
   submitEvidence(true);
 });
 
+// --- Form Templates ---
+
+const TEMPLATE_STORAGE_KEY = "evidence_templates";
+const TEMPLATE_DEFAULT_FIELDS = ["repo", "branch", "rcs_ref", "procedure_ref", "evidence_type", "source", "tags"];
+
+function loadTemplates() {
+  try {
+    return JSON.parse(localStorage.getItem(TEMPLATE_STORAGE_KEY)) || [];
+  } catch { return []; }
+}
+
+function saveTemplates(templates) {
+  localStorage.setItem(TEMPLATE_STORAGE_KEY, JSON.stringify(templates));
+}
+
+function refreshTemplateDropdown() {
+  const sel = document.getElementById("template-select");
+  const current = sel.value;
+  sel.innerHTML = `<option value="">-- No template --</option>`;
+  for (const tpl of loadTemplates()) {
+    const opt = document.createElement("option");
+    opt.value = tpl.id;
+    opt.textContent = tpl.name;
+    sel.appendChild(opt);
+  }
+  sel.value = current || "";
+}
+
+function applyTemplate(templateId) {
+  const form = document.getElementById("add-form");
+  const cfList = document.getElementById("custom-fields-list");
+
+  if (!templateId) {
+    for (const f of TEMPLATE_DEFAULT_FIELDS) {
+      const input = form.querySelector(`[name="${f}"]`);
+      if (input) input.value = f === "evidence_type" ? "manual" : "";
+    }
+    cfList.innerHTML = "";
+    return;
+  }
+
+  const tpl = loadTemplates().find(t => t.id === templateId);
+  if (!tpl) return;
+
+  for (const f of TEMPLATE_DEFAULT_FIELDS) {
+    const input = form.querySelector(`[name="${f}"]`);
+    if (input) input.value = (tpl.defaults && tpl.defaults[f]) || (f === "evidence_type" ? "manual" : "");
+  }
+
+  cfList.innerHTML = "";
+  if (tpl.customFields) {
+    for (const cf of tpl.customFields) {
+      const row = document.createElement("div");
+      row.className = "custom-field-row grid";
+      row.innerHTML = `
+        <input type="text" value="${esc(cf.key)}" class="cf-key" readonly title="${esc(cf.label || cf.key)}">
+        <input type="text" placeholder="${esc(cf.placeholder || "")}" class="cf-value">
+        <button type="button" class="secondary outline cf-remove">&times;</button>
+      `;
+      row.querySelector(".cf-remove").addEventListener("click", () => row.remove());
+      cfList.appendChild(row);
+    }
+  }
+}
+
+document.getElementById("template-select").addEventListener("change", (e) => {
+  applyTemplate(e.target.value);
+});
+
+// --- Template Management Dialog ---
+
+const templateDialog = document.getElementById("template-dialog");
+
+document.getElementById("close-template-dialog").addEventListener("click", () => {
+  templateDialog.close();
+});
+
+document.getElementById("template-manage").addEventListener("click", () => {
+  renderTemplateList();
+  templateDialog.showModal();
+});
+
+function renderTemplateList() {
+  document.getElementById("template-dialog-title").textContent = "Manage Templates";
+  const content = document.getElementById("template-dialog-content");
+  const templates = loadTemplates();
+
+  let html = "";
+  if (templates.length === 0) {
+    html += `<p style="color:var(--pico-muted-color);font-size:0.9em">No templates yet.</p>`;
+  } else {
+    for (const tpl of templates) {
+      html += `
+        <div class="template-list-item">
+          <span>${esc(tpl.name)}</span>
+          <div class="template-list-actions">
+            <button class="secondary outline" data-edit="${tpl.id}">Edit</button>
+            <button class="secondary outline" data-delete="${tpl.id}">&times;</button>
+          </div>
+        </div>`;
+    }
+  }
+  html += `<div style="margin-top:0.5em"><button class="secondary" id="tpl-create-new" style="width:auto;padding:0.3em 0.8em;font-size:0.85em">+ Create New</button></div>`;
+  html += `
+    <div class="template-import-export">
+      <button class="secondary outline" id="tpl-export">Export All</button>
+      <button class="secondary outline" id="tpl-import-btn">Import</button>
+      <input type="file" id="tpl-import-file" accept=".json" hidden>
+    </div>`;
+
+  content.innerHTML = html;
+
+  content.querySelector("#tpl-create-new").addEventListener("click", () => renderTemplateEditor(null));
+  content.querySelectorAll("[data-edit]").forEach(btn => {
+    btn.addEventListener("click", () => renderTemplateEditor(btn.dataset.edit));
+  });
+  content.querySelectorAll("[data-delete]").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const templates = loadTemplates().filter(t => t.id !== btn.dataset.delete);
+      saveTemplates(templates);
+      refreshTemplateDropdown();
+      renderTemplateList();
+    });
+  });
+  content.querySelector("#tpl-export").addEventListener("click", exportTemplates);
+  content.querySelector("#tpl-import-btn").addEventListener("click", () => {
+    content.querySelector("#tpl-import-file").click();
+  });
+  content.querySelector("#tpl-import-file").addEventListener("change", (e) => {
+    if (e.target.files[0]) importTemplates(e.target.files[0]);
+  });
+}
+
+function renderTemplateEditor(templateId) {
+  document.getElementById("template-dialog-title").textContent = templateId ? "Edit Template" : "New Template";
+  const content = document.getElementById("template-dialog-content");
+  const tpl = templateId ? loadTemplates().find(t => t.id === templateId) : null;
+  const defaults = (tpl && tpl.defaults) || {};
+  const customFields = (tpl && tpl.customFields) || [];
+
+  let fieldsHtml = customFields.map((cf, i) => `
+    <div class="template-field-def" data-idx="${i}">
+      <input type="text" value="${esc(cf.key)}" placeholder="key" class="tfd-key">
+      <input type="text" value="${esc(cf.label)}" placeholder="label" class="tfd-label">
+      <input type="text" value="${esc(cf.placeholder || "")}" placeholder="placeholder" class="tfd-placeholder">
+      <button type="button" class="secondary outline cf-remove">&times;</button>
+    </div>`).join("");
+
+  content.innerHTML = `
+    <div class="template-editor">
+      <label>Template name
+        <input type="text" id="tpl-ed-name" value="${esc(tpl ? tpl.name : "")}" placeholder="My Template" required>
+      </label>
+      <fieldset>
+        <legend>Default values</legend>
+        <div class="grid">
+          <label>Repo <input type="text" id="tpl-def-repo" value="${esc(defaults.repo || "")}"></label>
+          <label>Branch <input type="text" id="tpl-def-branch" value="${esc(defaults.branch || "")}"></label>
+        </div>
+        <div class="grid">
+          <label>Commit <input type="text" id="tpl-def-rcs_ref" value="${esc(defaults.rcs_ref || "")}"></label>
+          <label>Procedure <input type="text" id="tpl-def-procedure_ref" value="${esc(defaults.procedure_ref || "")}"></label>
+        </div>
+        <div class="grid">
+          <label>Evidence type <input type="text" id="tpl-def-evidence_type" value="${esc(defaults.evidence_type || "")}"></label>
+          <label>Source <input type="text" id="tpl-def-source" value="${esc(defaults.source || "")}"></label>
+        </div>
+        <label>Tags <input type="text" id="tpl-def-tags" value="${esc(defaults.tags || "")}"></label>
+      </fieldset>
+      <fieldset>
+        <legend>Custom metadata fields</legend>
+        <div id="tpl-field-defs">${fieldsHtml}</div>
+        <button type="button" class="secondary outline" id="tpl-add-field" style="font-size:0.8em;padding:0.2em 0.6em;width:auto;margin-top:0.3em">+ Add field</button>
+      </fieldset>
+      <div class="filter-actions" style="margin-top:0.5em">
+        <button id="tpl-ed-save">Save</button>
+        <button class="secondary" id="tpl-ed-cancel">Cancel</button>
+      </div>
+    </div>`;
+
+  content.querySelectorAll(".cf-remove").forEach(btn => {
+    btn.addEventListener("click", () => btn.closest(".template-field-def").remove());
+  });
+
+  content.querySelector("#tpl-add-field").addEventListener("click", () => {
+    const defs = content.querySelector("#tpl-field-defs");
+    const row = document.createElement("div");
+    row.className = "template-field-def";
+    row.innerHTML = `
+      <input type="text" placeholder="key" class="tfd-key">
+      <input type="text" placeholder="label" class="tfd-label">
+      <input type="text" placeholder="placeholder" class="tfd-placeholder">
+      <button type="button" class="secondary outline cf-remove">&times;</button>
+    `;
+    row.querySelector(".cf-remove").addEventListener("click", () => row.remove());
+    defs.appendChild(row);
+    row.querySelector(".tfd-key").focus();
+  });
+
+  content.querySelector("#tpl-ed-cancel").addEventListener("click", () => renderTemplateList());
+
+  content.querySelector("#tpl-ed-save").addEventListener("click", () => {
+    const name = content.querySelector("#tpl-ed-name").value.trim();
+    if (!name) { content.querySelector("#tpl-ed-name").focus(); return; }
+
+    const newDefaults = {};
+    for (const f of TEMPLATE_DEFAULT_FIELDS) {
+      const v = content.querySelector(`#tpl-def-${f}`).value.trim();
+      if (v) newDefaults[f] = v;
+    }
+
+    const newFields = [];
+    content.querySelectorAll(".template-field-def").forEach(row => {
+      const key = row.querySelector(".tfd-key").value.trim();
+      const label = row.querySelector(".tfd-label").value.trim();
+      const placeholder = row.querySelector(".tfd-placeholder").value.trim();
+      if (key) newFields.push({ key, label: label || key, placeholder });
+    });
+
+    const templates = loadTemplates();
+    if (templateId) {
+      const idx = templates.findIndex(t => t.id === templateId);
+      if (idx !== -1) {
+        templates[idx] = { ...templates[idx], name, defaults: newDefaults, customFields: newFields };
+      }
+    } else {
+      templates.push({ id: "tpl_" + Date.now(), name, defaults: newDefaults, customFields: newFields });
+    }
+    saveTemplates(templates);
+    refreshTemplateDropdown();
+    renderTemplateList();
+  });
+}
+
+// --- Save Current Form as Template ---
+
+document.getElementById("template-save-current").addEventListener("click", () => {
+  const form = document.getElementById("add-form");
+  const defaults = {};
+  for (const f of TEMPLATE_DEFAULT_FIELDS) {
+    const v = form.querySelector(`[name="${f}"]`).value.trim();
+    if (v) defaults[f] = v;
+  }
+
+  const customFields = [];
+  document.querySelectorAll(".custom-field-row").forEach(row => {
+    const key = row.querySelector(".cf-key").value.trim();
+    if (key) {
+      customFields.push({ key, label: key, placeholder: "" });
+    }
+  });
+
+  const templates = loadTemplates();
+  const tpl = { id: "tpl_" + Date.now(), name: "", defaults, customFields };
+  templates.push(tpl);
+  saveTemplates(templates);
+  refreshTemplateDropdown();
+
+  renderTemplateEditor(tpl.id);
+  templateDialog.showModal();
+});
+
+// --- Template Import/Export ---
+
+function exportTemplates() {
+  const data = JSON.stringify(loadTemplates(), null, 2);
+  const blob = new Blob([data], { type: "application/json" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "evidence-templates.json";
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+function importTemplates(file) {
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const imported = JSON.parse(reader.result);
+      if (!Array.isArray(imported)) throw new Error("Expected an array");
+      const existing = loadTemplates();
+      const existingIds = new Set(existing.map(t => t.id));
+      for (const tpl of imported) {
+        if (!tpl.id || !tpl.name) continue;
+        if (existingIds.has(tpl.id)) {
+          const idx = existing.findIndex(t => t.id === tpl.id);
+          existing[idx] = tpl;
+        } else {
+          existing.push(tpl);
+        }
+      }
+      saveTemplates(existing);
+      refreshTemplateDropdown();
+      renderTemplateList();
+    } catch (err) {
+      alert(`Import failed: ${err.message}`);
+    }
+  };
+  reader.readAsText(file);
+}
+
 // --- Init ---
 
 (async function init() {
   checkHealth();
+  refreshTemplateDropdown();
   document.querySelector('#add-form [name="finished_at"]').value = formatTime(new Date().toISOString());
   const filters = readFiltersFromURL();
   populateFormFromFilters(filters);

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -22,6 +22,17 @@
     <main class="container">
         <section id="tab-add" class="tab-content" hidden>
             <h4>Add Manual Test Result</h4>
+            <div id="template-bar">
+                <label>Template
+                    <span class="input-with-button">
+                        <select id="template-select">
+                            <option value="">-- No template --</option>
+                        </select>
+                        <button type="button" class="secondary outline" id="template-manage" title="Manage templates">Manage</button>
+                        <button type="button" class="secondary outline" id="template-save-current" title="Save current form as template">Save as Template</button>
+                    </span>
+                </label>
+            </div>
             <form id="add-form">
                 <div class="grid">
                     <label>Repo <small>(required)</small>
@@ -145,6 +156,16 @@
         </div>
 
         </section>
+
+        <dialog id="template-dialog">
+            <article>
+                <header>
+                    <button aria-label="Close" rel="prev" id="close-template-dialog"></button>
+                    <h3 id="template-dialog-title">Manage Templates</h3>
+                </header>
+                <div id="template-dialog-content"></div>
+            </article>
+        </dialog>
 
         <dialog id="detail-dialog">
             <article>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -291,6 +291,114 @@
     font-size: 0.9em;
 }
 
+/* Template bar */
+#template-bar {
+    margin-bottom: 0.5em;
+    padding-bottom: 0.5em;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+#template-bar label {
+    font-size: 0.8em;
+    margin-bottom: 0;
+}
+
+#template-select {
+    padding: 0.3em 0.5em;
+    font-size: 0.85em;
+    height: auto;
+}
+
+/* Template dialog */
+#template-dialog article {
+    max-width: 600px;
+}
+
+.template-list-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.4em 0;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+.template-list-item:last-child {
+    border-bottom: none;
+}
+
+.template-list-actions {
+    display: flex;
+    gap: 0.3em;
+}
+
+.template-list-actions button {
+    padding: 0.2em 0.5em;
+    font-size: 0.8em;
+    width: auto;
+}
+
+.template-editor label {
+    font-size: 0.8em;
+    margin-bottom: 0.2em;
+}
+
+.template-editor input,
+.template-editor select {
+    padding: 0.3em 0.5em;
+    font-size: 0.85em;
+    height: auto;
+    margin-bottom: 0.3em;
+}
+
+.template-editor .grid {
+    gap: 0.4em;
+    margin-bottom: 0.3em;
+}
+
+.template-editor fieldset {
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 4px;
+    padding: 0.5em 0.8em;
+    margin-bottom: 0.5em;
+}
+
+.template-editor fieldset legend {
+    font-size: 0.8em;
+    font-weight: 600;
+}
+
+.template-field-def {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr auto;
+    gap: 0.4em;
+    margin-bottom: 0.3em;
+    align-items: center;
+}
+
+.template-field-def input {
+    margin-bottom: 0 !important;
+}
+
+.template-import-export {
+    display: flex;
+    gap: 0.3em;
+    margin-top: 0.5em;
+    padding-top: 0.5em;
+    border-top: 1px solid var(--pico-muted-border-color);
+}
+
+.template-import-export button {
+    padding: 0.2em 0.5em;
+    font-size: 0.8em;
+    width: auto;
+}
+
+/* Read-only key for template-applied custom fields */
+.custom-field-row .cf-key[readonly] {
+    background: var(--pico-muted-border-color);
+    cursor: default;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     #results-table th:nth-child(n+5),


### PR DESCRIPTION
## Summary

- Adds an "Add Result" tab with a form for manual test evidence entry (repo, branch, commit, procedure, type, source, result, tags, notes, custom metadata)
- Adds **form templates** to pre-fill default values and define custom metadata fields per test scenario (e.g. outdoor tests with weather/video fields)
- Templates stored in localStorage with JSON import/export for team sharing
- "Save as Template" shortcut captures current form state into a new template
- "Submit & Add Another" re-applies the active template for efficient batch entry

## Test plan

- [ ] Open Add Result tab — template dropdown visible with "No template" selected
- [ ] Create a template via Manage dialog with defaults and custom fields
- [ ] Select template — form fills defaults, custom field rows appear with locked keys
- [ ] Submit evidence — verify metadata includes template custom fields
- [ ] "Submit & Add Another" — form resets to template defaults with empty custom field values
- [ ] Export templates to JSON, delete all, re-import — templates restored
- [ ] Verify ad-hoc custom fields still work alongside template fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)