### PR TITLE
Implement configurable retention rules

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/nesono/evidence-store/internal/config"
 	"github.com/nesono/evidence-store/internal/migrate"
+	"github.com/nesono/evidence-store/internal/retention"
 	"github.com/nesono/evidence-store/internal/server"
+	"github.com/nesono/evidence-store/internal/store"
 )
 
 func main() {
@@ -51,6 +53,24 @@ func main() {
 	slog.Info("database connected")
 
 	srv := server.New(cfg, pool)
+
+	// Start retention worker if configured.
+	if retentionPath := os.Getenv("EVIDENCE_RETENTION_CONFIG"); retentionPath != "" {
+		retCfg, err := retention.LoadConfig(retentionPath)
+		if err != nil {
+			slog.Error("failed to load retention config", "error", err, "path", retentionPath)
+			os.Exit(1)
+		}
+		evidenceStore := store.NewEvidenceStore(pool)
+		inheritanceStore := store.NewInheritanceStore(pool)
+		worker, err := retention.NewWorker(retCfg, evidenceStore, inheritanceStore, slog.Default())
+		if err != nil {
+			slog.Error("failed to create retention worker", "error", err)
+			os.Exit(1)
+		}
+		go worker.Start(ctx)
+		slog.Info("retention worker configured", "config", retentionPath, "interval", retCfg.Interval)
+	}
 
 	// Graceful shutdown on SIGINT/SIGTERM.
 	quit := make(chan os.Signal, 1)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.41.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -71,5 +72,4 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/grpc v1.79.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/retention/config.go
+++ b/internal/retention/config.go
@@ -1,0 +1,80 @@
+package retention
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds the retention configuration loaded from a YAML file.
+type Config struct {
+	Interval time.Duration `yaml:"interval"`
+	Rules    []Rule        `yaml:"rules"`
+}
+
+// Rule defines a single retention rule with regex-based field matching.
+type Rule struct {
+	Name     string            `yaml:"name"`
+	Match    map[string]string `yaml:"match"`
+	MaxAge   time.Duration     `yaml:"max_age"`
+	Priority int               `yaml:"priority"`
+}
+
+// validFields are the evidence fields that can be matched by retention rules.
+var validFields = map[string]bool{
+	"repo":          true,
+	"branch":        true,
+	"rcs_ref":       true,
+	"procedure_ref": true,
+	"evidence_type": true,
+	"source":        true,
+	"result":        true,
+}
+
+// LoadConfig reads and validates a retention config from a YAML file.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read retention config: %w", err)
+	}
+	return ParseConfig(data)
+}
+
+// ParseConfig parses and validates retention config from YAML bytes.
+func ParseConfig(data []byte) (*Config, error) {
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse retention config: %w", err)
+	}
+
+	if cfg.Interval <= 0 {
+		cfg.Interval = 24 * time.Hour
+	}
+
+	for i, rule := range cfg.Rules {
+		if rule.Name == "" {
+			return nil, fmt.Errorf("rule %d: name is required", i)
+		}
+		if rule.MaxAge < 0 {
+			return nil, fmt.Errorf("rule %q: max_age must be >= 0", rule.Name)
+		}
+		for field, pattern := range rule.Match {
+			if !validFields[field] {
+				return nil, fmt.Errorf("rule %q: unknown match field %q", rule.Name, field)
+			}
+			if _, err := regexp.Compile(pattern); err != nil {
+				return nil, fmt.Errorf("rule %q: invalid regex for field %q: %w", rule.Name, field, err)
+			}
+		}
+	}
+
+	sort.Slice(cfg.Rules, func(i, j int) bool {
+		return cfg.Rules[i].Priority > cfg.Rules[j].Priority
+	})
+
+	return &cfg, nil
+}

--- a/internal/retention/config_test.go
+++ b/internal/retention/config_test.go
@@ -1,0 +1,121 @@
+package retention
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfig_Valid(t *testing.T) {
+	yaml := `
+interval: 12h
+rules:
+  - name: keep-releases
+    match:
+      branch: "^(main|release/.*)$"
+    max_age: 0s
+    priority: 100
+  - name: default
+    match: {}
+    max_age: 2160h
+    priority: 0
+`
+	cfg, err := ParseConfig([]byte(yaml))
+	require.NoError(t, err)
+
+	assert.Equal(t, 12*time.Hour, cfg.Interval)
+	require.Len(t, cfg.Rules, 2)
+	// Sorted by priority descending.
+	assert.Equal(t, "keep-releases", cfg.Rules[0].Name)
+	assert.Equal(t, 100, cfg.Rules[0].Priority)
+	assert.Equal(t, "default", cfg.Rules[1].Name)
+	assert.Equal(t, time.Duration(0), cfg.Rules[0].MaxAge)
+	assert.Equal(t, 2160*time.Hour, cfg.Rules[1].MaxAge)
+}
+
+func TestParseConfig_DefaultInterval(t *testing.T) {
+	yaml := `
+rules:
+  - name: default
+    match: {}
+    max_age: 720h
+`
+	cfg, err := ParseConfig([]byte(yaml))
+	require.NoError(t, err)
+	assert.Equal(t, 24*time.Hour, cfg.Interval)
+}
+
+func TestParseConfig_InvalidRegex(t *testing.T) {
+	yaml := `
+rules:
+  - name: bad
+    match:
+      branch: "[invalid"
+    max_age: 24h
+`
+	_, err := ParseConfig([]byte(yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid regex")
+}
+
+func TestParseConfig_UnknownField(t *testing.T) {
+	yaml := `
+rules:
+  - name: bad
+    match:
+      nonexistent: ".*"
+    max_age: 24h
+`
+	_, err := ParseConfig([]byte(yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown match field")
+}
+
+func TestParseConfig_MissingName(t *testing.T) {
+	yaml := `
+rules:
+  - match: {}
+    max_age: 24h
+`
+	_, err := ParseConfig([]byte(yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name is required")
+}
+
+func TestParseConfig_NegativeMaxAge(t *testing.T) {
+	yaml := `
+rules:
+  - name: bad
+    match: {}
+    max_age: -1h
+`
+	_, err := ParseConfig([]byte(yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_age must be >= 0")
+}
+
+func TestParseConfig_SortsByPriority(t *testing.T) {
+	yaml := `
+rules:
+  - name: low
+    match: {}
+    max_age: 24h
+    priority: 10
+  - name: high
+    match: {}
+    max_age: 24h
+    priority: 90
+  - name: mid
+    match: {}
+    max_age: 24h
+    priority: 50
+`
+	cfg, err := ParseConfig([]byte(yaml))
+	require.NoError(t, err)
+	require.Len(t, cfg.Rules, 3)
+	assert.Equal(t, "high", cfg.Rules[0].Name)
+	assert.Equal(t, "mid", cfg.Rules[1].Name)
+	assert.Equal(t, "low", cfg.Rules[2].Name)
+}

--- a/internal/retention/evaluator.go
+++ b/internal/retention/evaluator.go
@@ -1,0 +1,85 @@
+package retention
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/nesono/evidence-store/internal/model"
+)
+
+// compiledRule is a retention rule with pre-compiled regexes.
+type compiledRule struct {
+	name     string
+	matchers map[string]*regexp.Regexp
+	maxAge   time.Duration
+}
+
+// Evaluator matches evidence records against compiled retention rules.
+type Evaluator struct {
+	rules []compiledRule
+}
+
+// NewEvaluator compiles the rules from a Config into an Evaluator.
+// Rules must already be sorted by priority (descending) — LoadConfig does this.
+func NewEvaluator(cfg *Config) (*Evaluator, error) {
+	rules := make([]compiledRule, 0, len(cfg.Rules))
+	for _, r := range cfg.Rules {
+		cr := compiledRule{
+			name:     r.Name,
+			matchers: make(map[string]*regexp.Regexp, len(r.Match)),
+			maxAge:   r.MaxAge,
+		}
+		for field, pattern := range r.Match {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return nil, err // should not happen — already validated by ParseConfig
+			}
+			cr.matchers[field] = re
+		}
+		rules = append(rules, cr)
+	}
+	return &Evaluator{rules: rules}, nil
+}
+
+// fieldValue extracts a matchable field value from an evidence record.
+func fieldValue(ev *model.Evidence, field string) string {
+	switch field {
+	case "repo":
+		return ev.Repo
+	case "branch":
+		return ev.Branch
+	case "rcs_ref":
+		return ev.RCSRef
+	case "procedure_ref":
+		return ev.ProcedureRef
+	case "evidence_type":
+		return ev.EvidenceType
+	case "source":
+		return ev.Source
+	case "result":
+		return string(ev.Result)
+	default:
+		return ""
+	}
+}
+
+// MaxAge returns the max_age of the first matching rule for the given evidence record.
+// Returns -1 if no rule matches (record should not be deleted).
+func (e *Evaluator) MaxAge(ev *model.Evidence) time.Duration {
+	for _, rule := range e.rules {
+		if matchesRule(ev, rule) {
+			return rule.maxAge
+		}
+	}
+	return -1
+}
+
+func matchesRule(ev *model.Evidence, rule compiledRule) bool {
+	for field, re := range rule.matchers {
+		val := fieldValue(ev, field)
+		if !re.MatchString(val) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/retention/evaluator_test.go
+++ b/internal/retention/evaluator_test.go
@@ -1,0 +1,104 @@
+package retention
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nesono/evidence-store/internal/model"
+)
+
+func buildEvaluator(t *testing.T, rules []Rule) *Evaluator {
+	t.Helper()
+	cfg := &Config{Rules: rules}
+	ev, err := NewEvaluator(cfg)
+	require.NoError(t, err)
+	return ev
+}
+
+func TestEvaluator_FirstMatchWins(t *testing.T) {
+	eval := buildEvaluator(t, []Rule{
+		{Name: "keep-releases", Match: map[string]string{"branch": "^main$"}, MaxAge: 0},
+		{Name: "default", Match: map[string]string{}, MaxAge: 2160 * time.Hour},
+	})
+
+	ev := &model.Evidence{Branch: "main", Result: model.ResultPass}
+	assert.Equal(t, time.Duration(0), eval.MaxAge(ev))
+
+	ev2 := &model.Evidence{Branch: "feature/foo", Result: model.ResultPass}
+	assert.Equal(t, 2160*time.Hour, eval.MaxAge(ev2))
+}
+
+func TestEvaluator_RegexMatching(t *testing.T) {
+	eval := buildEvaluator(t, []Rule{
+		{Name: "release-branches", Match: map[string]string{"branch": "^(main|release/.*)$"}, MaxAge: 0},
+		{Name: "default", Match: map[string]string{}, MaxAge: 720 * time.Hour},
+	})
+
+	tests := []struct {
+		branch string
+		want   time.Duration
+	}{
+		{"main", 0},
+		{"release/v1.0", 0},
+		{"release/v2.3.4", 0},
+		{"feature/login", 720 * time.Hour},
+		{"pr/123", 720 * time.Hour},
+	}
+	for _, tt := range tests {
+		ev := &model.Evidence{Branch: tt.branch, Result: model.ResultPass}
+		assert.Equal(t, tt.want, eval.MaxAge(ev), "branch=%q", tt.branch)
+	}
+}
+
+func TestEvaluator_MultiFieldAND(t *testing.T) {
+	eval := buildEvaluator(t, []Rule{
+		{
+			Name:   "manual-on-main",
+			Match:  map[string]string{"branch": "^main$", "evidence_type": "^manual$"},
+			MaxAge: 8760 * time.Hour,
+		},
+		{Name: "default", Match: map[string]string{}, MaxAge: 720 * time.Hour},
+	})
+
+	// Both fields match.
+	ev := &model.Evidence{Branch: "main", EvidenceType: "manual", Result: model.ResultPass}
+	assert.Equal(t, 8760*time.Hour, eval.MaxAge(ev))
+
+	// Only one field matches — falls through to default.
+	ev2 := &model.Evidence{Branch: "main", EvidenceType: "bazel", Result: model.ResultPass}
+	assert.Equal(t, 720*time.Hour, eval.MaxAge(ev2))
+
+	ev3 := &model.Evidence{Branch: "feature/x", EvidenceType: "manual", Result: model.ResultPass}
+	assert.Equal(t, 720*time.Hour, eval.MaxAge(ev3))
+}
+
+func TestEvaluator_NoMatchReturnsNegative(t *testing.T) {
+	eval := buildEvaluator(t, []Rule{
+		{Name: "only-main", Match: map[string]string{"branch": "^main$"}, MaxAge: 720 * time.Hour},
+	})
+
+	ev := &model.Evidence{Branch: "develop", Result: model.ResultPass}
+	assert.Equal(t, time.Duration(-1), eval.MaxAge(ev))
+}
+
+func TestEvaluator_EmptyMatchMatchesAll(t *testing.T) {
+	eval := buildEvaluator(t, []Rule{
+		{Name: "catch-all", Match: map[string]string{}, MaxAge: 720 * time.Hour},
+	})
+
+	ev := &model.Evidence{Branch: "anything", Repo: "whatever", Result: model.ResultFail}
+	assert.Equal(t, 720*time.Hour, eval.MaxAge(ev))
+}
+
+func TestEvaluator_ResultFieldMatching(t *testing.T) {
+	eval := buildEvaluator(t, []Rule{
+		{Name: "keep-failures", Match: map[string]string{"result": "^FAIL$"}, MaxAge: 8760 * time.Hour},
+		{Name: "default", Match: map[string]string{}, MaxAge: 720 * time.Hour},
+	})
+
+	assert.Equal(t, 8760*time.Hour, eval.MaxAge(&model.Evidence{Result: model.ResultFail}))
+	assert.Equal(t, 720*time.Hour, eval.MaxAge(&model.Evidence{Result: model.ResultPass}))
+}

--- a/internal/retention/worker.go
+++ b/internal/retention/worker.go
@@ -1,0 +1,151 @@
+package retention
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nesono/evidence-store/internal/model"
+	"github.com/nesono/evidence-store/internal/store"
+)
+
+const defaultBatchSize = 1000
+
+// Worker runs retention rules on a schedule.
+type Worker struct {
+	evaluator *Evaluator
+	evidence  *store.EvidenceStore
+	inherit   *store.InheritanceStore
+	interval  time.Duration
+	logger    *slog.Logger
+}
+
+// NewWorker creates a new retention worker.
+func NewWorker(cfg *Config, evidence *store.EvidenceStore, inherit *store.InheritanceStore, logger *slog.Logger) (*Worker, error) {
+	eval, err := NewEvaluator(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Worker{
+		evaluator: eval,
+		evidence:  evidence,
+		inherit:   inherit,
+		interval:  cfg.Interval,
+		logger:    logger,
+	}, nil
+}
+
+// Start runs the retention worker on a ticker. Blocks until ctx is cancelled.
+func (w *Worker) Start(ctx context.Context) {
+	w.logger.Info("retention worker started", "interval", w.interval)
+
+	// Run once immediately on start.
+	deleted, err := w.RunOnce(ctx)
+	if err != nil {
+		w.logger.Error("retention run failed", "error", err)
+	} else {
+		w.logger.Info("retention run completed", "deleted", deleted)
+	}
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("retention worker stopped")
+			return
+		case <-ticker.C:
+			deleted, err := w.RunOnce(ctx)
+			if err != nil {
+				w.logger.Error("retention run failed", "error", err)
+			} else {
+				w.logger.Info("retention run completed", "deleted", deleted)
+			}
+		}
+	}
+}
+
+// RunOnce executes a single retention pass. Returns the total number of deleted records.
+func (w *Worker) RunOnce(ctx context.Context) (int, error) {
+	// Build the inheritance exemption set.
+	inheritedRefs, err := w.inherit.AllSourceRefs(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	now := time.Now()
+	var totalDeleted int
+
+	err = w.evidence.ScanAll(ctx, defaultBatchSize, func(batch []model.Evidence) error {
+		var toDelete []uuid.UUID
+
+		for i := range batch {
+			ev := &batch[i]
+
+			if isPinned(ev) {
+				continue
+			}
+
+			if isInheritanceProtected(ev, inheritedRefs) {
+				continue
+			}
+
+			maxAge := w.evaluator.MaxAge(ev)
+			if maxAge < 0 {
+				// No rule matched — don't delete.
+				continue
+			}
+			if maxAge == 0 {
+				// max_age=0 means keep forever.
+				continue
+			}
+
+			age := now.Sub(ev.FinishedAt)
+			if age >= maxAge {
+				toDelete = append(toDelete, ev.ID)
+			}
+		}
+
+		if len(toDelete) > 0 {
+			deleted, err := w.evidence.DeleteBatch(ctx, toDelete)
+			if err != nil {
+				return err
+			}
+			totalDeleted += int(deleted)
+		}
+
+		return nil
+	})
+
+	return totalDeleted, err
+}
+
+// isPinned checks if an evidence record has metadata.retain = true.
+func isPinned(ev *model.Evidence) bool {
+	if ev.Metadata == nil {
+		return false
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(ev.Metadata, &m); err != nil {
+		return false
+	}
+	retainRaw, ok := m["retain"]
+	if !ok {
+		return false
+	}
+	var retain bool
+	if err := json.Unmarshal(retainRaw, &retain); err != nil {
+		return false
+	}
+	return retain
+}
+
+// isInheritanceProtected checks if the evidence record's rcs_ref is referenced by an inheritance declaration.
+func isInheritanceProtected(ev *model.Evidence, inheritedRefs map[string]struct{}) bool {
+	_, ok := inheritedRefs[ev.Repo+"\x00"+ev.RCSRef]
+	return ok
+}

--- a/internal/retention/worker_test.go
+++ b/internal/retention/worker_test.go
@@ -1,0 +1,103 @@
+package retention
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nesono/evidence-store/internal/model"
+)
+
+func TestIsPinned(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata string
+		want     bool
+	}{
+		{"nil metadata", "", false},
+		{"empty object", `{}`, false},
+		{"retain true", `{"retain": true}`, true},
+		{"retain false", `{"retain": false}`, false},
+		{"retain string", `{"retain": "yes"}`, false},
+		{"other fields only", `{"tags": ["manual"]}`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := &model.Evidence{}
+			if tt.metadata != "" {
+				ev.Metadata = json.RawMessage(tt.metadata)
+			}
+			assert.Equal(t, tt.want, isPinned(ev))
+		})
+	}
+}
+
+func TestIsInheritanceProtected(t *testing.T) {
+	refs := map[string]struct{}{
+		"org/repo\x00abc123": {},
+	}
+
+	ev := &model.Evidence{Repo: "org/repo", RCSRef: "abc123"}
+	assert.True(t, isInheritanceProtected(ev, refs))
+
+	ev2 := &model.Evidence{Repo: "org/repo", RCSRef: "def456"}
+	assert.False(t, isInheritanceProtected(ev2, refs))
+
+	ev3 := &model.Evidence{Repo: "org/other", RCSRef: "abc123"}
+	assert.False(t, isInheritanceProtected(ev3, refs))
+}
+
+func TestEvaluator_MaxAgeZeroMeansKeepForever(t *testing.T) {
+	// This tests that the worker logic treats max_age=0 as "keep forever".
+	// We verify through the evaluator that the rule returns 0.
+	eval := buildEvaluator(t, []Rule{
+		{Name: "keep-forever", Match: map[string]string{"branch": "^main$"}, MaxAge: 0},
+	})
+
+	ev := &model.Evidence{Branch: "main", Result: model.ResultPass}
+	assert.Equal(t, time.Duration(0), eval.MaxAge(ev))
+}
+
+func TestWorkerLogic_DeleteExpired(t *testing.T) {
+	// Simulate worker decision logic without DB.
+	eval := buildEvaluator(t, []Rule{
+		{Name: "keep-releases", Match: map[string]string{"branch": "^main$"}, MaxAge: 0},
+		{Name: "default", Match: map[string]string{}, MaxAge: 720 * time.Hour},
+	})
+	inheritedRefs := map[string]struct{}{
+		"org/repo\x00protected-ref": {},
+	}
+	now := time.Now()
+
+	records := []model.Evidence{
+		{ID: uuid.New(), Branch: "main", Repo: "org/repo", RCSRef: "ref1", FinishedAt: now.Add(-1000 * time.Hour), Result: model.ResultPass},                                                    // main → keep forever
+		{ID: uuid.New(), Branch: "feature/x", Repo: "org/repo", RCSRef: "ref2", FinishedAt: now.Add(-1000 * time.Hour), Result: model.ResultPass},                                               // expired, should delete
+		{ID: uuid.New(), Branch: "feature/y", Repo: "org/repo", RCSRef: "ref3", FinishedAt: now.Add(-100 * time.Hour), Result: model.ResultPass},                                                // not expired
+		{ID: uuid.New(), Branch: "feature/z", Repo: "org/repo", RCSRef: "protected-ref", FinishedAt: now.Add(-1000 * time.Hour), Result: model.ResultPass},                                      // inheritance protected
+		{ID: uuid.New(), Branch: "feature/w", Repo: "org/repo", RCSRef: "ref5", FinishedAt: now.Add(-1000 * time.Hour), Result: model.ResultPass, Metadata: json.RawMessage(`{"retain":true}`)}, // pinned
+	}
+
+	var toDelete []uuid.UUID
+	for i := range records {
+		ev := &records[i]
+		if isPinned(ev) {
+			continue
+		}
+		if isInheritanceProtected(ev, inheritedRefs) {
+			continue
+		}
+		maxAge := eval.MaxAge(ev)
+		if maxAge <= 0 {
+			continue
+		}
+		if now.Sub(ev.FinishedAt) >= maxAge {
+			toDelete = append(toDelete, ev.ID)
+		}
+	}
+
+	assert.Len(t, toDelete, 1, "only the expired feature/x record should be deleted")
+	assert.Equal(t, records[1].ID, toDelete[0])
+}

--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -209,6 +209,78 @@ func scanEvidenceRow(rows pgx.Rows) (*model.Evidence, error) {
 	return &e, nil
 }
 
+// DeleteBatch deletes evidence records by IDs and returns the number of rows deleted.
+func (s *EvidenceStore) DeleteBatch(ctx context.Context, ids []uuid.UUID) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	tag, err := s.pool.Exec(ctx, `DELETE FROM evidence WHERE id = ANY($1)`, ids)
+	if err != nil {
+		return 0, fmt.Errorf("delete evidence batch: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// ScanAll iterates over all evidence records ordered by finished_at ASC in batches,
+// calling fn for each batch. Stops if fn returns an error.
+func (s *EvidenceStore) ScanAll(ctx context.Context, batchSize int, fn func([]model.Evidence) error) error {
+	var lastFinishedAt *string
+	var lastID *uuid.UUID
+
+	for {
+		var where string
+		var args []any
+
+		if lastFinishedAt != nil && lastID != nil {
+			where = " WHERE (finished_at, id) > ($1, $2)"
+			args = []any{*lastFinishedAt, *lastID}
+		}
+
+		query := fmt.Sprintf(
+			"SELECT id, repo, branch, rcs_ref, procedure_ref, evidence_type, source, result, finished_at, ingested_at, metadata FROM evidence%s ORDER BY finished_at ASC, id ASC LIMIT %d",
+			where, batchSize,
+		)
+
+		rows, err := s.pool.Query(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("scan evidence: %w", err)
+		}
+
+		var batch []model.Evidence
+		for rows.Next() {
+			ev, err := scanEvidenceRow(rows)
+			if err != nil {
+				rows.Close()
+				return err
+			}
+			batch = append(batch, *ev)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("scan evidence rows: %w", err)
+		}
+
+		if len(batch) == 0 {
+			break
+		}
+
+		if err := fn(batch); err != nil {
+			return err
+		}
+
+		last := batch[len(batch)-1]
+		ts := last.FinishedAt.Format("2006-01-02T15:04:05.999999Z07:00")
+		lastFinishedAt = &ts
+		lastID = &last.ID
+
+		if len(batch) < batchSize {
+			break
+		}
+	}
+
+	return nil
+}
+
 func mustJSON(v any) json.RawMessage {
 	b, _ := json.Marshal(v)
 	return b

--- a/internal/store/inheritance.go
+++ b/internal/store/inheritance.go
@@ -90,6 +90,26 @@ func (s *InheritanceStore) List(ctx context.Context, filter model.InheritanceFil
 	return results, rows.Err()
 }
 
+// AllSourceRefs returns the set of all (repo, source_rcs_ref) pairs from active inheritance declarations.
+// The returned map keys are "repo\x00source_rcs_ref" for efficient lookup.
+func (s *InheritanceStore) AllSourceRefs(ctx context.Context) (map[string]struct{}, error) {
+	rows, err := s.pool.Query(ctx, `SELECT DISTINCT repo, source_rcs_ref FROM inheritance_declaration`)
+	if err != nil {
+		return nil, fmt.Errorf("query inheritance source refs: %w", err)
+	}
+	defer rows.Close()
+
+	refs := make(map[string]struct{})
+	for rows.Next() {
+		var repo, ref string
+		if err := rows.Scan(&repo, &ref); err != nil {
+			return nil, fmt.Errorf("scan inheritance source ref: %w", err)
+		}
+		refs[repo+"\x00"+ref] = struct{}{}
+	}
+	return refs, rows.Err()
+}
+
 // FindForTarget returns all inheritance declarations for a given repo + target rcs_ref.
 func (s *InheritanceStore) FindForTarget(ctx context.Context, repo, targetRCSRef string) ([]model.InheritanceDeclaration, error) {
 	return s.List(ctx, model.InheritanceFilter{

--- a/migrations/000002_drop_retention_policy_table.down.sql
+++ b/migrations/000002_drop_retention_policy_table.down.sql
@@ -1,0 +1,7 @@
+CREATE TABLE retention_policy (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    evidence_type   TEXT,
+    max_age_days    INT NOT NULL,
+    keep_failures   BOOLEAN NOT NULL DEFAULT true,
+    priority        INT NOT NULL DEFAULT 0
+);

--- a/migrations/000002_drop_retention_policy_table.up.sql
+++ b/migrations/000002_drop_retention_policy_table.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS retention_policy;

--- a/retention.example.yaml
+++ b/retention.example.yaml
@@ -1,0 +1,34 @@
+# Evidence Store — Retention Configuration
+#
+# Point the server to this file via:
+#   EVIDENCE_RETENTION_CONFIG=retention.yaml
+#
+# Rules are evaluated in priority order (highest first). First match wins.
+# max_age: 0s means "keep forever". Records with metadata.retain=true are
+# always exempt. Records referenced by inheritance declarations are always exempt.
+
+interval: 24h
+
+rules:
+  - name: keep-releases-forever
+    match:
+      branch: "^(main|release/.*)$"
+    max_age: 0s
+    priority: 100
+
+  - name: keep-failures-1y
+    match:
+      result: "^FAIL$"
+    max_age: 8760h
+    priority: 90
+
+  - name: pr-branches-short
+    match:
+      branch: "^(pr/|dependabot/|renovate/).*"
+    max_age: 336h   # 14 days
+    priority: 50
+
+  - name: default
+    match: {}
+    max_age: 2160h  # 90 days
+    priority: 0

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -23,9 +24,16 @@ import (
 	"github.com/nesono/evidence-store/internal/migrate"
 	"github.com/nesono/evidence-store/internal/model"
 	"github.com/nesono/evidence-store/internal/server"
+	"github.com/nesono/evidence-store/internal/store"
 )
 
-var testServer *httptest.Server
+var (
+	testServer           *httptest.Server
+	testPool             *pgxpool.Pool
+	testEvidenceStore    *store.EvidenceStore
+	testInheritanceStore *store.InheritanceStore
+	testLogger           = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+)
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
@@ -68,6 +76,10 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	defer pool.Close()
+
+	testPool = pool
+	testEvidenceStore = store.NewEvidenceStore(pool)
+	testInheritanceStore = store.NewInheritanceStore(pool)
 
 	cfg := &config.Config{
 		DatabaseURL:     dbURL,

--- a/tests/retention_integration_test.go
+++ b/tests/retention_integration_test.go
@@ -1,0 +1,229 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nesono/evidence-store/internal/model"
+	"github.com/nesono/evidence-store/internal/retention"
+)
+
+// ---------------------------------------------------------------------------
+// Tests: Retention
+// ---------------------------------------------------------------------------
+
+func TestRetentionDeletesExpiredRecords(t *testing.T) {
+	repo := "org/ret_expired_" + uuid.New().String()[:8]
+
+	// Insert an old record (100 days ago) on a feature branch.
+	ev := makeEvidence(repo, "feature/old", "ret_old1", "//pkg:test", "ci", model.ResultPass)
+	resp := postJSON(t, "/api/v1/evidence", ev)
+	require.Equal(t, 201, resp.StatusCode)
+	old := decodeJSON[model.Evidence](t, resp)
+
+	// Backdate it via direct update through test server.
+	backdateEvidence(t, old.ID, 100*24*time.Hour)
+
+	// Insert a recent record on same branch.
+	ev2 := makeEvidence(repo, "feature/new", "ret_new1", "//pkg:test", "ci", model.ResultPass)
+	resp = postJSON(t, "/api/v1/evidence", ev2)
+	require.Equal(t, 201, resp.StatusCode)
+	recent := decodeJSON[model.Evidence](t, resp)
+
+	// Run retention with 90-day default.
+	cfg := mustParseRetentionConfig(t, `
+interval: 1h
+rules:
+  - name: default
+    match: {}
+    max_age: 2160h
+    priority: 0
+`)
+	deleted := runRetention(t, cfg)
+	assert.GreaterOrEqual(t, deleted, 1)
+
+	// Old record should be gone.
+	resp = getJSON(t, "/api/v1/evidence/"+old.ID.String())
+	assert.Equal(t, 404, resp.StatusCode)
+	resp.Body.Close()
+
+	// Recent record should still exist.
+	resp = getJSON(t, "/api/v1/evidence/"+recent.ID.String())
+	assert.Equal(t, 200, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestRetentionKeepsForeverOnMaxAgeZero(t *testing.T) {
+	repo := "org/ret_forever_" + uuid.New().String()[:8]
+
+	ev := makeEvidence(repo, "main", "ret_main1", "//pkg:test", "ci", model.ResultPass)
+	resp := postJSON(t, "/api/v1/evidence", ev)
+	require.Equal(t, 201, resp.StatusCode)
+	created := decodeJSON[model.Evidence](t, resp)
+
+	backdateEvidence(t, created.ID, 365*24*time.Hour)
+
+	cfg := mustParseRetentionConfig(t, `
+interval: 1h
+rules:
+  - name: keep-main
+    match:
+      branch: "^main$"
+    max_age: 0s
+    priority: 100
+  - name: default
+    match: {}
+    max_age: 720h
+    priority: 0
+`)
+	runRetention(t, cfg)
+
+	resp = getJSON(t, "/api/v1/evidence/"+created.ID.String())
+	assert.Equal(t, 200, resp.StatusCode, "main branch record should be kept forever")
+	resp.Body.Close()
+}
+
+func TestRetentionRespectsPinnedRecords(t *testing.T) {
+	repo := "org/ret_pinned_" + uuid.New().String()[:8]
+
+	ev := makeEvidence(repo, "feature/x", "ret_pin1", "//pkg:test", "ci", model.ResultPass)
+	ev.Metadata = json.RawMessage(`{"retain": true}`)
+	resp := postJSON(t, "/api/v1/evidence", ev)
+	require.Equal(t, 201, resp.StatusCode)
+	pinned := decodeJSON[model.Evidence](t, resp)
+
+	backdateEvidence(t, pinned.ID, 200*24*time.Hour)
+
+	cfg := mustParseRetentionConfig(t, `
+interval: 1h
+rules:
+  - name: default
+    match: {}
+    max_age: 720h
+    priority: 0
+`)
+	runRetention(t, cfg)
+
+	resp = getJSON(t, "/api/v1/evidence/"+pinned.ID.String())
+	assert.Equal(t, 200, resp.StatusCode, "pinned record should survive retention")
+	resp.Body.Close()
+}
+
+func TestRetentionRespectsInheritance(t *testing.T) {
+	repo := "org/ret_inh_" + uuid.New().String()[:8]
+
+	// Insert evidence for a source commit.
+	ev := makeEvidence(repo, "feature/z", "inh_src_ref", "//pkg:test", "ci", model.ResultPass)
+	resp := postJSON(t, "/api/v1/evidence", ev)
+	require.Equal(t, 201, resp.StatusCode)
+	srcRecord := decodeJSON[model.Evidence](t, resp)
+
+	backdateEvidence(t, srcRecord.ID, 200*24*time.Hour)
+
+	// Create an inheritance declaration referencing this source.
+	resp = postJSON(t, "/api/v1/inheritance", model.InheritanceCreate{
+		Repo:          repo,
+		SourceRCSRef:  "inh_src_ref",
+		TargetRCSRef:  "inh_tgt_ref",
+		Scope:         json.RawMessage(`[]`),
+		Justification: "test",
+		CreatedBy:     "ci",
+	})
+	require.Equal(t, 201, resp.StatusCode)
+	resp.Body.Close()
+
+	cfg := mustParseRetentionConfig(t, `
+interval: 1h
+rules:
+  - name: default
+    match: {}
+    max_age: 720h
+    priority: 0
+`)
+	runRetention(t, cfg)
+
+	resp = getJSON(t, "/api/v1/evidence/"+srcRecord.ID.String())
+	assert.Equal(t, 200, resp.StatusCode, "inheritance-protected record should survive retention")
+	resp.Body.Close()
+}
+
+func TestRetentionRegexBranchMatching(t *testing.T) {
+	repo := "org/ret_regex_" + uuid.New().String()[:8]
+
+	// Insert a PR branch record (short retention) and a release branch record (long retention).
+	evPR := makeEvidence(repo, "pr/123", "ret_pr1", "//pkg:test", "ci", model.ResultPass)
+	resp := postJSON(t, "/api/v1/evidence", evPR)
+	require.Equal(t, 201, resp.StatusCode)
+	prRecord := decodeJSON[model.Evidence](t, resp)
+	backdateEvidence(t, prRecord.ID, 20*24*time.Hour) // 20 days old
+
+	evRelease := makeEvidence(repo, "release/v1.0", "ret_rel1", "//pkg:test", "ci", model.ResultPass)
+	resp = postJSON(t, "/api/v1/evidence", evRelease)
+	require.Equal(t, 201, resp.StatusCode)
+	relRecord := decodeJSON[model.Evidence](t, resp)
+	backdateEvidence(t, relRecord.ID, 20*24*time.Hour) // 20 days old
+
+	cfg := mustParseRetentionConfig(t, `
+interval: 1h
+rules:
+  - name: keep-releases
+    match:
+      branch: "^release/.*$"
+    max_age: 0s
+    priority: 100
+  - name: short-pr
+    match:
+      branch: "^pr/.*$"
+    max_age: 336h
+    priority: 50
+  - name: default
+    match: {}
+    max_age: 2160h
+    priority: 0
+`)
+	runRetention(t, cfg)
+
+	// PR record (20 days > 14 days) should be deleted.
+	resp = getJSON(t, "/api/v1/evidence/"+prRecord.ID.String())
+	assert.Equal(t, 404, resp.StatusCode, "PR branch record should be deleted after 14 days")
+	resp.Body.Close()
+
+	// Release record should survive (keep forever).
+	resp = getJSON(t, "/api/v1/evidence/"+relRecord.ID.String())
+	assert.Equal(t, 200, resp.StatusCode, "release branch record should be kept forever")
+	resp.Body.Close()
+}
+
+// ---------------------------------------------------------------------------
+// Retention test helpers
+// ---------------------------------------------------------------------------
+
+func mustParseRetentionConfig(t *testing.T, yaml string) *retention.Config {
+	t.Helper()
+	cfg, err := retention.ParseConfig([]byte(yaml))
+	require.NoError(t, err)
+	return cfg
+}
+
+func runRetention(t *testing.T, cfg *retention.Config) int {
+	t.Helper()
+	worker, err := retention.NewWorker(cfg, testEvidenceStore, testInheritanceStore, testLogger)
+	require.NoError(t, err)
+	deleted, err := worker.RunOnce(context.Background())
+	require.NoError(t, err)
+	return deleted
+}
+
+func backdateEvidence(t *testing.T, id uuid.UUID, age time.Duration) {
+	t.Helper()
+	newTime := time.Now().UTC().Add(-age)
+	_, err := testPool.Exec(context.Background(),
+		"UPDATE evidence SET finished_at = $1 WHERE id = $2", newTime, id)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Implements #10 — configurable retention rules with regex-based field matching.

- **YAML config file** (`EVIDENCE_RETENTION_CONFIG` env var) defines priority-ordered rules with regex matching on any evidence field
- **Background worker** runs on a configurable interval (default 24h), scanning all records and batch-deleting expired ones
- **Exemptions**: records with `metadata.retain=true` (pinned) and records referenced by inheritance declarations are never deleted
- **`max_age: 0s`** means keep forever — useful for release branches
- **Migration** drops the unused `retention_policy` DB table (superseded by config file approach)
- **Example config** at `retention.example.yaml` with common rules (keep releases forever, failures 1y, PR branches 14d, default 90d)

### New files
- `internal/retention/` — config loader, evaluator (rule matching), worker (scan + delete)
- `migrations/000002_drop_retention_policy_table.{up,down}.sql`
- `retention.example.yaml`
- `tests/retention_integration_test.go`

### Modified files
- `internal/store/evidence.go` — added `DeleteBatch`, `ScanAll`
- `internal/store/inheritance.go` — added `AllSourceRefs`
- `cmd/server/main.go` — wire up retention worker
- `tests/integration_test.go` — expose pool/stores for retention tests

## Test plan

- [x] Unit tests: config parsing, regex validation, priority sorting (7 tests)
- [x] Unit tests: evaluator rule matching, multi-field AND, first-match-wins (6 tests)
- [x] Unit tests: isPinned, isInheritanceProtected, worker decision logic (4 tests)
- [x] Integration tests with testcontainers Postgres (5 tests):
  - Deletes expired records
  - Keeps records when max_age=0 (forever)
  - Respects pinned records (metadata.retain=true)
  - Respects inheritance-protected records
  - Regex branch matching (PR vs release)
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)