### PR TITLE
Support regex search in evidence queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Evidence Store
 
-A backend service for ingesting, storing, and querying test evidence from heterogeneous sources.
+A backend service for ingesting, storing, and querying test evidence from heterogeneous sources (Bazel test logs, CI pipelines, manual test runs, HiL/PiL/vehicle tests).
+
+Evidence Store provides a unified API to collect and query test results across different tools and workflows. It supports batch ingestion, cursor-based pagination, evidence inheritance across commits, configurable retention policies, and a web UI for manual test entry and search with regex filtering.
 
 ## Quick Start
 
@@ -116,7 +118,32 @@ curl "http://localhost:8000/api/v1/evidence?finished_after=2026-01-01T00:00:00Z"
 curl "http://localhost:8000/api/v1/evidence?limit=10&cursor=<next_cursor>"
 ```
 
-**Query parameters:** `repo`, `branch`, `rcs_ref`, `evidence_type`, `source`, `procedure_ref`, `result`, `finished_after`, `finished_before`, `tags`, `limit`, `cursor`, `include_inherited`.
+**Query parameters:** `repo`, `branch`, `rcs_ref`, `evidence_type`, `source`, `procedure_ref`, `result`, `finished_after`, `finished_before`, `tags`, `notes`, `limit`, `cursor`, `include_inherited`.
+
+### Regex filtering
+
+Text filter fields support regex matching via a `~` prefix. Without the prefix, filters use exact matching (backwards-compatible).
+
+```bash
+# Exact match (default)
+curl "http://localhost:8000/api/v1/evidence?branch=main"
+
+# Regex match — all release branches
+curl "http://localhost:8000/api/v1/evidence?branch=~^release/.*"
+
+# Regex on multiple fields — bazel-* types on org repos
+curl "http://localhost:8000/api/v1/evidence?evidence_type=~^bazel&repo=~^myorg/"
+
+# Regex on tags — match any tag starting with "nightly-"
+curl "http://localhost:8000/api/v1/evidence?tags=~^nightly-"
+
+# Regex on notes
+curl "http://localhost:8000/api/v1/evidence?notes=~device.*XYZ"
+```
+
+**Supported fields:** `repo`, `branch`, `rcs_ref`, `evidence_type`, `source`, `procedure_ref`, `tags`, `notes`.
+
+The regex engine is [PostgreSQL POSIX regular expressions](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP) (the `~` operator). This supports the POSIX Extended Regular Expression syntax including character classes (`[a-z]`, `[[:digit:]]`), alternation (`a|b`), quantifiers (`*`, `+`, `?`, `{n,m}`), and anchors (`^`, `$`). Matching is case-sensitive.
 
 ## Development
 

--- a/internal/api/evidence.go
+++ b/internal/api/evidence.go
@@ -187,6 +187,9 @@ func (h *EvidenceHandler) List(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("tags"); v != "" {
 		filter.Tags = strings.Split(v, ",")
 	}
+	if v := q.Get("notes"); v != "" {
+		filter.Notes = &v
+	}
 
 	limit := h.cfg.DefaultPageSize
 	if v := q.Get("limit"); v != "" {

--- a/internal/model/evidence.go
+++ b/internal/model/evidence.go
@@ -69,6 +69,7 @@ type EvidenceFilter struct {
 	FinishedAfter  *time.Time
 	FinishedBefore *time.Time
 	Tags           []string
+	Notes          *string
 }
 
 type BatchRequest struct {

--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -105,27 +105,32 @@ func (s *EvidenceStore) List(ctx context.Context, params ListParams) (*ListResul
 		return s
 	}
 
-	if v := params.Filter.Repo; v != nil {
-		where = append(where, fmt.Sprintf("repo = %s", arg(*v)))
+	textFilter := func(column string, v *string) {
+		if v == nil {
+			return
+		}
+		val := *v
+		if strings.HasPrefix(val, "~") {
+			where = append(where, fmt.Sprintf("%s ~ %s", column, arg(val[1:])))
+		} else {
+			where = append(where, fmt.Sprintf("%s = %s", column, arg(val)))
+		}
 	}
-	if v := params.Filter.RCSRef; v != nil {
-		where = append(where, fmt.Sprintf("rcs_ref = %s", arg(*v)))
-	}
-	if v := params.Filter.Branch; v != nil {
-		where = append(where, fmt.Sprintf("branch = %s", arg(*v)))
-	}
-	if v := params.Filter.EvidenceType; v != nil {
-		where = append(where, fmt.Sprintf("evidence_type = %s", arg(*v)))
-	}
-	if v := params.Filter.Source; v != nil {
-		where = append(where, fmt.Sprintf("source = %s", arg(*v)))
-	}
+
+	textFilter("repo", params.Filter.Repo)
+	textFilter("rcs_ref", params.Filter.RCSRef)
+	textFilter("branch", params.Filter.Branch)
+	textFilter("evidence_type", params.Filter.EvidenceType)
+	textFilter("source", params.Filter.Source)
 	if v := params.Filter.ProcedureRef; v != nil {
-		if strings.HasSuffix(*v, "*") {
-			prefix := strings.TrimSuffix(*v, "*")
+		val := *v
+		if strings.HasPrefix(val, "~") {
+			where = append(where, fmt.Sprintf("procedure_ref ~ %s", arg(val[1:])))
+		} else if strings.HasSuffix(val, "*") {
+			prefix := strings.TrimSuffix(val, "*")
 			where = append(where, fmt.Sprintf("procedure_ref LIKE %s", arg(prefix+"%")))
 		} else {
-			where = append(where, fmt.Sprintf("procedure_ref = %s", arg(*v)))
+			where = append(where, fmt.Sprintf("procedure_ref = %s", arg(val)))
 		}
 	}
 	if len(params.Filter.Result) > 0 {
@@ -142,7 +147,23 @@ func (s *EvidenceStore) List(ctx context.Context, params ListParams) (*ListResul
 		where = append(where, fmt.Sprintf("finished_at < %s", arg(*v)))
 	}
 	if len(params.Filter.Tags) > 0 {
-		where = append(where, fmt.Sprintf("metadata->'tags' @> %s", arg(mustJSON(params.Filter.Tags))))
+		// If the first tag starts with ~, treat all tags as regex patterns.
+		if strings.HasPrefix(params.Filter.Tags[0], "~") {
+			for _, t := range params.Filter.Tags {
+				pattern := strings.TrimPrefix(t, "~")
+				where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM jsonb_array_elements_text(metadata->'tags') tag WHERE tag ~ %s)", arg(pattern)))
+			}
+		} else {
+			where = append(where, fmt.Sprintf("metadata->'tags' @> %s", arg(mustJSON(params.Filter.Tags))))
+		}
+	}
+	if v := params.Filter.Notes; v != nil {
+		val := *v
+		if strings.HasPrefix(val, "~") {
+			where = append(where, fmt.Sprintf("metadata->>'notes' ~ %s", arg(val[1:])))
+		} else {
+			where = append(where, fmt.Sprintf("metadata->>'notes' = %s", arg(val)))
+		}
 	}
 	if params.Cursor != nil {
 		where = append(where, fmt.Sprintf("(ingested_at, id) > (%s, %s)", arg(params.Cursor.IngestedAt), arg(params.Cursor.ID)))

--- a/tests/regex_search_test.go
+++ b/tests/regex_search_test.go
@@ -1,0 +1,164 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nesono/evidence-store/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// Tests: Regex Search
+// ---------------------------------------------------------------------------
+
+func TestSearchRegexRepo(t *testing.T) {
+	base := "org/regex_repo_" + uuid.New().String()[:8]
+	repo1 := base + "_alpha"
+	repo2 := base + "_beta"
+
+	for _, repo := range []string{repo1, repo2} {
+		ev := makeEvidence(repo, "main", "ref1", "//pkg:test", "ci", model.ResultPass)
+		resp := postJSON(t, "/api/v1/evidence", ev)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	// Exact match — only repo1.
+	resp := getJSON(t, "/api/v1/evidence?repo="+url.QueryEscape(repo1))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result := decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 1)
+
+	// Regex match — both.
+	resp = getJSON(t, "/api/v1/evidence?repo="+url.QueryEscape("~"+base+"_.*"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result = decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 2)
+}
+
+func TestSearchRegexBranch(t *testing.T) {
+	repo := "org/regex_branch_" + uuid.New().String()[:8]
+
+	for _, branch := range []string{"release/v1.0", "release/v2.0", "feature/login"} {
+		ev := makeEvidence(repo, branch, "ref1", "//pkg:test", "ci", model.ResultPass)
+		resp := postJSON(t, "/api/v1/evidence", ev)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	resp := getJSON(t, "/api/v1/evidence?repo="+repo+"&branch="+url.QueryEscape("~^release/.*"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result := decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 2)
+}
+
+func TestSearchRegexProcedure(t *testing.T) {
+	repo := "org/regex_proc_" + uuid.New().String()[:8]
+
+	for _, proc := range []string{"//pkg/a:test1", "//pkg/a:test2", "//pkg/b:test1"} {
+		ev := makeEvidence(repo, "main", "ref1", proc, "ci", model.ResultPass)
+		resp := postJSON(t, "/api/v1/evidence", ev)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	// Regex to match //pkg/a:* only.
+	resp := getJSON(t, "/api/v1/evidence?repo="+repo+"&procedure_ref="+url.QueryEscape("~^//pkg/a:.*"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result := decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 2)
+}
+
+func TestSearchRegexEvidenceType(t *testing.T) {
+	repo := "org/regex_type_" + uuid.New().String()[:8]
+
+	for _, etype := range []string{"bazel", "manual", "bazeltool"} {
+		ev := makeEvidence(repo, "main", "ref1", "//pkg:test", "ci", model.ResultPass)
+		ev.EvidenceType = etype
+		resp := postJSON(t, "/api/v1/evidence", ev)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	resp := getJSON(t, "/api/v1/evidence?repo="+repo+"&evidence_type="+url.QueryEscape("~^bazel"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result := decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 2) // bazel and bazeltool
+}
+
+func TestSearchRegexTags(t *testing.T) {
+	repo := "org/regex_tags_" + uuid.New().String()[:8]
+
+	ev1 := makeEvidence(repo, "main", "ref1", "//pkg:test1", "ci", model.ResultPass)
+	ev1.Metadata = json.RawMessage(`{"tags": ["nightly-x86", "regression"]}`)
+	resp := postJSON(t, "/api/v1/evidence", ev1)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	ev2 := makeEvidence(repo, "main", "ref1", "//pkg:test2", "ci", model.ResultPass)
+	ev2.Metadata = json.RawMessage(`{"tags": ["nightly-arm64", "smoke"]}`)
+	resp = postJSON(t, "/api/v1/evidence", ev2)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	ev3 := makeEvidence(repo, "main", "ref1", "//pkg:test3", "ci", model.ResultPass)
+	ev3.Metadata = json.RawMessage(`{"tags": ["manual"]}`)
+	resp = postJSON(t, "/api/v1/evidence", ev3)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	// Regex tag search for nightly-*.
+	resp = getJSON(t, "/api/v1/evidence?repo="+repo+"&tags="+url.QueryEscape("~^nightly-"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result := decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 2)
+}
+
+func TestSearchNotes(t *testing.T) {
+	repo := "org/regex_notes_" + uuid.New().String()[:8]
+
+	ev1 := makeEvidence(repo, "main", "ref1", "//pkg:test1", "ci", model.ResultPass)
+	ev1.Metadata = json.RawMessage(`{"notes": "Tested on device XYZ-100"}`)
+	resp := postJSON(t, "/api/v1/evidence", ev1)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	ev2 := makeEvidence(repo, "main", "ref1", "//pkg:test2", "ci", model.ResultPass)
+	ev2.Metadata = json.RawMessage(`{"notes": "Tested on device ABC-200"}`)
+	resp = postJSON(t, "/api/v1/evidence", ev2)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	// Exact notes match.
+	resp = getJSON(t, "/api/v1/evidence?repo="+repo+"&notes="+url.QueryEscape("Tested on device XYZ-100"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result := decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 1)
+
+	// Regex notes match.
+	resp = getJSON(t, "/api/v1/evidence?repo="+repo+"&notes="+url.QueryEscape("~device.*-[12]00"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result = decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 2)
+}
+
+func TestSearchExactStillWorks(t *testing.T) {
+	repo := "org/regex_exact_" + uuid.New().String()[:8]
+
+	ev := makeEvidence(repo, "main", "ref1", "//pkg:test", "ci", model.ResultPass)
+	resp := postJSON(t, "/api/v1/evidence", ev)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	// Exact match should still work as before.
+	resp = getJSON(t, "/api/v1/evidence?repo="+url.QueryEscape(repo)+"&branch=main")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result := decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 1)
+}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,7 +1,7 @@
 const API_BASE = "/api/v1";
 
 const TEXT_FIELDS = [
-  "repo", "branch", "rcs_ref", "evidence_type", "source", "procedure_ref", "tags",
+  "repo", "branch", "rcs_ref", "evidence_type", "source", "procedure_ref", "tags", "notes",
 ];
 const DATETIME_FIELDS = ["finished_after", "finished_before"];
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -94,15 +94,16 @@
         <details id="filter-panel" open>
             <summary>Filters</summary>
             <form id="filter-form">
+                <small class="regex-hint">Prefix with <code>~</code> for regex, e.g. <code>~^org/.*</code></small>
                 <div class="grid">
-                    <label>Repo <input type="text" name="repo" placeholder="org/repo"></label>
-                    <label>Branch <input type="text" name="branch" placeholder="main"></label>
+                    <label>Repo <input type="text" name="repo" placeholder="org/repo or ~^org/.*"></label>
+                    <label>Branch <input type="text" name="branch" placeholder="main or ~^release/.*"></label>
                     <label>Commit <input type="text" name="rcs_ref" placeholder="abc123..."></label>
                 </div>
                 <div class="grid">
-                    <label>Evidence type <input type="text" name="evidence_type" placeholder="bazel"></label>
+                    <label>Evidence type <input type="text" name="evidence_type" placeholder="bazel or ~^(bazel|manual)$"></label>
                     <label>Source <input type="text" name="source" placeholder="CI URL or user"></label>
-                    <label>Procedure <input type="text" name="procedure_ref" placeholder="//pkg:target"></label>
+                    <label>Procedure <input type="text" name="procedure_ref" placeholder="//pkg:target or ~//pkg/.*"></label>
                 </div>
                 <div class="grid">
                     <fieldset>
@@ -116,8 +117,11 @@
                     <label>Before <input type="text" name="finished_before" placeholder="2026-12-31 23:59"></label>
                 </div>
                 <div class="grid">
-                    <label>Tags <input type="text" name="tags" placeholder="ci,nightly"></label>
+                    <label>Tags <input type="text" name="tags" placeholder="ci,nightly or ~^reg.*"></label>
+                    <label>Notes <input type="text" name="notes" placeholder="keyword or ~pattern"></label>
                     <label>Limit <input type="number" name="limit" min="1" max="1000" placeholder="100"></label>
+                </div>
+                <div class="grid">
                     <label style="align-self:end"><input type="checkbox" name="include_inherited" checked> Include inherited</label>
                 </div>
                 <div class="filter-actions">

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -15,6 +15,21 @@
 .badge-skipped { background: #888;    color: #fff; }
 .badge-tag     { background: #e0e0e0; color: #333; font-weight: 400; }
 
+/* Regex hint */
+.regex-hint {
+    display: block;
+    color: var(--pico-muted-color);
+    font-size: 0.75em;
+    margin-bottom: 0.3em;
+}
+
+.regex-hint code {
+    background: var(--pico-muted-border-color);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+    font-size: 0.95em;
+}
+
 /* Compact forms */
 #filter-form label,
 #add-form label {


### PR DESCRIPTION
## Summary

Closes #11 — adds regex matching to search filters using a `~` prefix convention.

- **`~` prefix** on any text filter enables PostgreSQL regex matching (e.g., `?branch=~^release/.*`)
- **Supported fields**: repo, branch, rcs_ref, evidence_type, source, procedure_ref, tags, notes
- **Tags regex**: `?tags=~^nightly-` matches any tag matching the pattern via `jsonb_array_elements_text`
- **New `notes` filter**: `?notes=~device.*` searches `metadata.notes` (exact or regex)
- **Backwards-compatible**: existing exact-match queries work unchanged
- **Frontend**: updated placeholders with regex examples, added hint bar above search form

## Test plan

- [x] Integration tests (7 new tests):
  - Regex on repo, branch, procedure_ref, evidence_type
  - Regex on tags (JSONB array)
  - Exact and regex notes search
  - Existing exact-match still works
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)