### PR TITLE
Ensure all datetimes are normalized to UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ curl -X POST http://localhost:8000/api/v1/evidence \
 
 Result must be one of: `PASS`, `FAIL`, `ERROR`, `SKIPPED`.
 
+`finished_at` accepts RFC3339 (`2026-01-01T00:00:00Z`, `2026-01-01T12:00:00+02:00`) as well as shorter forms (`2026-01-01 14:00`, `2026-01-01`). Values without a timezone are interpreted as **UTC**. All timestamps are normalized to UTC on storage.
+
 ### Querying evidence
 
 ```bash

--- a/internal/api/evidence.go
+++ b/internal/api/evidence.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -169,7 +168,7 @@ func (h *EvidenceHandler) List(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if v := q.Get("finished_after"); v != "" {
-		t, err := time.Parse(time.RFC3339, v)
+		t, err := model.ParseFlexibleTime(v)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid finished_after: "+err.Error())
 			return
@@ -177,7 +176,7 @@ func (h *EvidenceHandler) List(w http.ResponseWriter, r *http.Request) {
 		filter.FinishedAfter = &t
 	}
 	if v := q.Get("finished_before"); v != "" {
-		t, err := time.Parse(time.RFC3339, v)
+		t, err := model.ParseFlexibleTime(v)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid finished_before: "+err.Error())
 			return

--- a/internal/model/evidence.go
+++ b/internal/model/evidence.go
@@ -3,10 +3,60 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+// FlexibleTime accepts multiple datetime formats during JSON unmarshalling
+// and normalizes them to UTC. Supported formats:
+//   - RFC3339 / RFC3339Nano (with timezone)
+//   - "2006-01-02T15:04:05" (zoneless, treated as UTC)
+//   - "2006-01-02 15:04:05" (zoneless, treated as UTC)
+//   - "2006-01-02 15:04"    (zoneless, treated as UTC)
+//   - "2006-01-02"          (date only, 00:00:00 UTC)
+type FlexibleTime struct {
+	time.Time
+}
+
+var flexibleTimeLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+	"2006-01-02 15:04",
+	"2006-01-02",
+}
+
+// ParseFlexibleTime parses a datetime string in any of the supported formats
+// and returns the result normalized to UTC.
+func ParseFlexibleTime(s string) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	for _, layout := range flexibleTimeLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognized datetime %q (expected RFC3339 or YYYY-MM-DD[ HH:MM[:SS]])", s)
+}
+
+func (ft *FlexibleTime) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	t, err := ParseFlexibleTime(s)
+	if err != nil {
+		return err
+	}
+	ft.Time = t
+	return nil
+}
+
+func (ft FlexibleTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ft.Time.UTC())
+}
 
 type EvidenceResult string
 
@@ -47,7 +97,7 @@ type EvidenceCreate struct {
 	EvidenceType string          `json:"evidence_type"`
 	Source       string          `json:"source"`
 	Result       EvidenceResult  `json:"result"`
-	FinishedAt   time.Time       `json:"finished_at"`
+	FinishedAt   FlexibleTime    `json:"finished_at"`
 	Metadata     json.RawMessage `json:"metadata,omitempty"`
 }
 

--- a/internal/model/flextime_test.go
+++ b/internal/model/flextime_test.go
@@ -1,0 +1,140 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFlexibleTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:  "RFC3339 UTC",
+			input: "2026-03-30T14:00:00Z",
+			want:  time.Date(2026, 3, 30, 14, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "RFC3339 with offset",
+			input: "2026-03-30T14:00:00+02:00",
+			want:  time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "RFC3339Nano",
+			input: "2026-03-30T14:00:00.123456789Z",
+			want:  time.Date(2026, 3, 30, 14, 0, 0, 123456789, time.UTC),
+		},
+		{
+			name:  "zoneless T separator",
+			input: "2026-03-30T14:00:00",
+			want:  time.Date(2026, 3, 30, 14, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "zoneless space separator",
+			input: "2026-03-30 14:00:00",
+			want:  time.Date(2026, 3, 30, 14, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "zoneless short (no seconds)",
+			input: "2026-03-30 14:00",
+			want:  time.Date(2026, 3, 30, 14, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "date only",
+			input: "2026-03-30",
+			want:  time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "whitespace trimmed",
+			input: "  2026-03-30 14:00  ",
+			want:  time.Date(2026, 3, 30, 14, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "invalid format",
+			input:   "not-a-date",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseFlexibleTime(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, time.UTC, got.Location(), "result must be in UTC")
+		})
+	}
+}
+
+func TestFlexibleTimeUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name: "RFC3339 UTC",
+			json: `{"t":"2026-03-30T14:00:00Z"}`,
+			want: time.Date(2026, 3, 30, 14, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "with offset normalizes to UTC",
+			json: `{"t":"2026-03-30T16:00:00+02:00"}`,
+			want: time.Date(2026, 3, 30, 14, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "zoneless treated as UTC",
+			json: `{"t":"2026-03-30 14:00"}`,
+			want: time.Date(2026, 3, 30, 14, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "date only",
+			json: `{"t":"2026-03-30"}`,
+			want: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "invalid",
+			json:    `{"t":"garbage"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var v struct {
+				T FlexibleTime `json:"t"`
+			}
+			err := json.Unmarshal([]byte(tt.json), &v)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, v.T.Time)
+		})
+	}
+}
+
+func TestFlexibleTimeMarshalJSON(t *testing.T) {
+	ft := FlexibleTime{Time: time.Date(2026, 3, 30, 14, 0, 0, 0, time.UTC)}
+	b, err := json.Marshal(ft)
+	require.NoError(t, err)
+	assert.Equal(t, `"2026-03-30T14:00:00Z"`, string(b))
+}

--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -31,7 +31,7 @@ func (s *EvidenceStore) Insert(ctx context.Context, e *model.EvidenceCreate) (*m
 		INSERT INTO evidence (repo, branch, rcs_ref, procedure_ref, evidence_type, source, result, finished_at, metadata)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		RETURNING id, repo, branch, rcs_ref, procedure_ref, evidence_type, source, result, finished_at, ingested_at, metadata
-	`, e.Repo, e.Branch, e.RCSRef, e.ProcedureRef, e.EvidenceType, e.Source, e.Result, e.FinishedAt, metadata)
+	`, e.Repo, e.Branch, e.RCSRef, e.ProcedureRef, e.EvidenceType, e.Source, e.Result, e.FinishedAt.UTC(), metadata)
 
 	return scanEvidence(row)
 }
@@ -54,7 +54,7 @@ func (s *EvidenceStore) InsertBatch(ctx context.Context, records []model.Evidenc
 			INSERT INTO evidence (repo, branch, rcs_ref, procedure_ref, evidence_type, source, result, finished_at, metadata)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 			RETURNING id, repo, branch, rcs_ref, procedure_ref, evidence_type, source, result, finished_at, ingested_at, metadata
-		`, e.Repo, e.Branch, e.RCSRef, e.ProcedureRef, e.EvidenceType, e.Source, e.Result, e.FinishedAt, metadata)
+		`, e.Repo, e.Branch, e.RCSRef, e.ProcedureRef, e.EvidenceType, e.Source, e.Result, e.FinishedAt.UTC(), metadata)
 
 		ev, err := scanEvidence(row)
 		if err != nil {
@@ -215,6 +215,8 @@ func scanEvidence(row pgx.Row) (*model.Evidence, error) {
 	if err != nil {
 		return nil, err
 	}
+	e.FinishedAt = e.FinishedAt.UTC()
+	e.IngestedAt = e.IngestedAt.UTC()
 	return &e, nil
 }
 
@@ -227,6 +229,8 @@ func scanEvidenceRow(rows pgx.Rows) (*model.Evidence, error) {
 	if err != nil {
 		return nil, err
 	}
+	e.FinishedAt = e.FinishedAt.UTC()
+	e.IngestedAt = e.IngestedAt.UTC()
 	return &e, nil
 }
 

--- a/internal/validate/evidence.go
+++ b/internal/validate/evidence.go
@@ -35,7 +35,7 @@ func EvidenceCreate(e *model.EvidenceCreate) []string {
 	if !e.Result.Valid() {
 		errs = append(errs, fmt.Sprintf("result %q is invalid, must be one of PASS, FAIL, ERROR, SKIPPED", e.Result))
 	}
-	if e.FinishedAt.IsZero() {
+	if e.FinishedAt.Time.IsZero() {
 		errs = append(errs, "finished_at is required")
 	}
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -17,7 +17,7 @@ func validEvidence() *model.EvidenceCreate {
 		EvidenceType: "bazel",
 		Source:       "ci-bot",
 		Result:       model.ResultPass,
-		FinishedAt:   time.Now(),
+		FinishedAt:   model.FlexibleTime{Time: time.Now()},
 	}
 }
 
@@ -38,7 +38,7 @@ func TestEvidenceCreateMissingFields(t *testing.T) {
 		{"missing procedure_ref", func(e *model.EvidenceCreate) { e.ProcedureRef = "" }, "procedure_ref is required"},
 		{"missing evidence_type", func(e *model.EvidenceCreate) { e.EvidenceType = "" }, "evidence_type is required"},
 		{"missing source", func(e *model.EvidenceCreate) { e.Source = "" }, "source is required"},
-		{"missing finished_at", func(e *model.EvidenceCreate) { e.FinishedAt = time.Time{} }, "finished_at is required"},
+		{"missing finished_at", func(e *model.EvidenceCreate) { e.FinishedAt = model.FlexibleTime{} }, "finished_at is required"},
 	}
 
 	for _, tt := range tests {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -134,7 +134,7 @@ func makeEvidence(repo, branch, rcsRef, procedureRef, source string, result mode
 		EvidenceType: "bazel",
 		Source:       source,
 		Result:       result,
-		FinishedAt:   time.Now().UTC().Truncate(time.Microsecond),
+		FinishedAt:   model.FlexibleTime{Time: time.Now().UTC().Truncate(time.Microsecond)},
 	}
 }
 
@@ -291,9 +291,9 @@ func TestListEvidenceFilterByTimeRange(t *testing.T) {
 
 	now := time.Now().UTC()
 	ev1 := makeEvidence(repo, "main", "ggg777", "//pkg:test", "ci", model.ResultPass)
-	ev1.FinishedAt = now.Add(-2 * time.Hour)
+	ev1.FinishedAt = model.FlexibleTime{Time: now.Add(-2 * time.Hour)}
 	ev2 := makeEvidence(repo, "main", "ggg777", "//pkg:test2", "ci", model.ResultPass)
-	ev2.FinishedAt = now.Add(-30 * time.Minute)
+	ev2.FinishedAt = model.FlexibleTime{Time: now.Add(-30 * time.Minute)}
 
 	for _, ev := range []model.EvidenceCreate{ev1, ev2} {
 		resp := postJSON(t, "/api/v1/evidence", ev)

--- a/tests/utc_normalization_test.go
+++ b/tests/utc_normalization_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nesono/evidence-store/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// Tests: UTC Normalization
+// ---------------------------------------------------------------------------
+
+func TestCreateEvidenceWithTimezoneOffset(t *testing.T) {
+	repo := "org/utc_offset_" + uuid.New().String()[:8]
+
+	// POST with +02:00 offset — should be stored as UTC (12:00Z).
+	body := map[string]string{
+		"repo":          repo,
+		"branch":        "main",
+		"rcs_ref":       "abc123",
+		"procedure_ref": "//pkg:test",
+		"evidence_type": "manual",
+		"source":        "tester",
+		"result":        "PASS",
+		"finished_at":   "2026-03-30T14:00:00+02:00",
+	}
+	resp := postJSON(t, "/api/v1/evidence", body)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	result := decodeJSON[model.Evidence](t, resp)
+	assert.Equal(t, "2026-03-30T12:00:00Z", result.FinishedAt.Format("2006-01-02T15:04:05Z07:00"))
+}
+
+func TestCreateEvidenceWithZonelessTime(t *testing.T) {
+	repo := "org/utc_zoneless_" + uuid.New().String()[:8]
+
+	// POST with zoneless datetime — should be treated as UTC.
+	body := map[string]string{
+		"repo":          repo,
+		"branch":        "main",
+		"rcs_ref":       "abc123",
+		"procedure_ref": "//pkg:test",
+		"evidence_type": "manual",
+		"source":        "tester",
+		"result":        "PASS",
+		"finished_at":   "2026-03-30 14:00",
+	}
+	resp := postJSON(t, "/api/v1/evidence", body)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	result := decodeJSON[model.Evidence](t, resp)
+	assert.Equal(t, "2026-03-30T14:00:00Z", result.FinishedAt.Format("2006-01-02T15:04:05Z07:00"))
+}
+
+func TestCreateEvidenceWithDateOnly(t *testing.T) {
+	repo := "org/utc_dateonly_" + uuid.New().String()[:8]
+
+	body := map[string]string{
+		"repo":          repo,
+		"branch":        "main",
+		"rcs_ref":       "abc123",
+		"procedure_ref": "//pkg:test",
+		"evidence_type": "manual",
+		"source":        "tester",
+		"result":        "PASS",
+		"finished_at":   "2026-03-30",
+	}
+	resp := postJSON(t, "/api/v1/evidence", body)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	result := decodeJSON[model.Evidence](t, resp)
+	assert.Equal(t, "2026-03-30T00:00:00Z", result.FinishedAt.Format("2006-01-02T15:04:05Z07:00"))
+}
+
+func TestFilterWithFlexibleDateFormats(t *testing.T) {
+	repo := "org/utc_filter_" + uuid.New().String()[:8]
+
+	ev := makeEvidence(repo, "main", "ref1", "//pkg:test", "ci", model.ResultPass)
+	resp := postJSON(t, "/api/v1/evidence", ev)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	// Filter with zoneless date — should be interpreted as UTC.
+	resp = getJSON(t, "/api/v1/evidence?repo="+url.QueryEscape(repo)+"&finished_after="+url.QueryEscape("2020-01-01 00:00"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result := decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 1)
+
+	// Filter with date-only.
+	resp = getJSON(t, "/api/v1/evidence?repo="+url.QueryEscape(repo)+"&finished_after="+url.QueryEscape("2020-01-01"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	result = decodeJSON[listResponse](t, resp)
+	assert.Len(t, result.Records, 1)
+}
+
+func TestResponseTimestampsAreUTC(t *testing.T) {
+	repo := "org/utc_resp_" + uuid.New().String()[:8]
+
+	ev := makeEvidence(repo, "main", "ref1", "//pkg:test", "ci", model.ResultPass)
+	resp := postJSON(t, "/api/v1/evidence", ev)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	result := decodeJSON[model.Evidence](t, resp)
+	assert.Equal(t, "UTC", result.FinishedAt.Location().String())
+	assert.Equal(t, "UTC", result.IngestedAt.Location().String())
+}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -48,8 +48,8 @@ function populateFormFromFilters(filters) {
   for (const f of DATETIME_FIELDS) {
     const input = form.querySelector(`[name="${f}"]`);
     if (input && filters[f]) {
-      const d = new Date(filters[f]);
-      input.value = isNaN(d.getTime()) ? filters[f] : formatTime(d.toISOString());
+      const d = parseUserDateTime(filters[f]);
+      input.value = d ? formatTime(d.toISOString()) : filters[f];
     }
   }
   const resultChecks = form.querySelectorAll('[name="result"]');
@@ -73,8 +73,8 @@ function readFormFilters() {
   for (const f of DATETIME_FIELDS) {
     const v = form.querySelector(`[name="${f}"]`).value.trim();
     if (v) {
-      const d = new Date(v);
-      filters[f] = isNaN(d.getTime()) ? v : d.toISOString();
+      const d = parseUserDateTime(v);
+      filters[f] = d ? d.toISOString() : v;
     }
   }
   const results = Array.from(form.querySelectorAll('[name="result"]:checked')).map(cb => cb.value);
@@ -140,7 +140,22 @@ function renderTags(metadata) {
 function formatTime(iso) {
   const d = new Date(iso);
   const pad = n => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
+}
+
+// Parse a user-entered datetime string. Zoneless values are treated as UTC.
+function parseUserDateTime(str) {
+  str = str.trim();
+  if (!str) return null;
+  // If the string has a timezone suffix (Z or +/-HH:MM), parse directly.
+  if (/Z$|[+-]\d{2}:?\d{2}$/.test(str)) {
+    const d = new Date(str);
+    return isNaN(d.getTime()) ? null : d;
+  }
+  // Zoneless — treat as UTC by appending Z (normalize separators first).
+  const normalized = str.replace(" ", "T");
+  const d = new Date(normalized + "Z");
+  return isNaN(d.getTime()) ? null : d;
 }
 
 function renderTable(records) {
@@ -327,9 +342,9 @@ async function submitEvidence(andAnother) {
   let finishedAt;
   const rawFinished = form.finished_at.value.trim();
   if (rawFinished) {
-    const d = new Date(rawFinished);
-    if (isNaN(d.getTime())) {
-      feedback.innerHTML = `<p class="feedback-error">Invalid date format. Use YYYY-MM-DD HH:MM</p>`;
+    const d = parseUserDateTime(rawFinished);
+    if (!d) {
+      feedback.innerHTML = `<p class="feedback-error">Invalid date format. Use YYYY-MM-DD HH:MM (UTC)</p>`;
       return;
     }
     finishedAt = d.toISOString();

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -64,10 +64,10 @@
                         <label><input type="radio" name="result" value="ERROR"> ERROR</label>
                         <label><input type="radio" name="result" value="SKIPPED"> SKIPPED</label>
                     </fieldset>
-                    <label>Finished at
+                    <label>Finished at <small>(UTC)</small>
                         <span class="input-with-button">
-                            <input type="text" name="finished_at" placeholder="2026-03-30 14:00">
-                            <button type="button" id="fill-now" class="secondary outline" title="Fill with current time">Now</button>
+                            <input type="text" name="finished_at" placeholder="2026-03-30 14:00 (UTC)">
+                            <button type="button" id="fill-now" class="secondary outline" title="Fill with current time (UTC)">Now</button>
                         </span>
                     </label>
                     <label>Tags
@@ -113,8 +113,8 @@
                         <label><input type="checkbox" name="result" value="ERROR"> ERROR</label>
                         <label><input type="checkbox" name="result" value="SKIPPED"> SKIPPED</label>
                     </fieldset>
-                    <label>After <input type="text" name="finished_after" placeholder="2026-01-01 00:00"></label>
-                    <label>Before <input type="text" name="finished_before" placeholder="2026-12-31 23:59"></label>
+                    <label>After <small>(UTC)</small> <input type="text" name="finished_after" placeholder="2026-01-01 00:00 (UTC)"></label>
+                    <label>Before <small>(UTC)</small> <input type="text" name="finished_before" placeholder="2026-12-31 23:59 (UTC)"></label>
                 </div>
                 <div class="grid">
                     <label>Tags <input type="text" name="tags" placeholder="ci,nightly or ~^reg.*"></label>


### PR DESCRIPTION
## Summary
- Add `FlexibleTime` type with custom JSON unmarshalling that accepts RFC3339, zoneless (`2026-03-30 14:00`), and date-only (`2026-03-30`) formats — all normalized to UTC
- Use `ParseFlexibleTime` for `finished_after`/`finished_before` query params (previously strict RFC3339 only)
- Force `.UTC()` on all timestamps returned from database scans
- Update web UI to display/interpret all datetime fields in UTC (labels, placeholders, `formatTime` uses `getUTC*` methods, new `parseUserDateTime` treats zoneless input as UTC)
- Add unit tests for `FlexibleTime`/`ParseFlexibleTime` and integration tests for timezone normalization

Closes #13

## Test plan
- [x] Unit tests: `ParseFlexibleTime` covers RFC3339, offset, zoneless, date-only, invalid
- [x] Unit tests: `FlexibleTime.UnmarshalJSON` and `MarshalJSON`
- [x] Integration: POST with `+02:00` offset → stored as UTC
- [x] Integration: POST with zoneless time → treated as UTC
- [x] Integration: POST with date-only → `00:00:00Z`
- [x] Integration: Filter with zoneless/date-only formats works
- [x] Integration: Response timestamps have UTC location
- [x] All 40 existing integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)