### PR TITLE
Add API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,35 @@ This starts PostgreSQL 16 and the Evidence Store server on port 8000.
 | `EVIDENCE_DEFAULT_PAGE_SIZE` | `100` | Default page size |
 | `EVIDENCE_MAX_PAGE_SIZE` | `1000` | Max page size |
 | `EVIDENCE_MAX_BATCH_SIZE` | `1000` | Max records per batch |
+| `EVIDENCE_API_KEYS` | *(empty — auth disabled)* | Comma-separated API keys (see [Authentication](#authentication)) |
+
+### Authentication
+
+Set `EVIDENCE_API_KEYS` to enable API key authentication for all `/api/v1/*` endpoints. The `/healthz` endpoint and static web UI files are always public.
+
+Each key entry has the format `role:key` where role is `rw` (read-write) or `ro` (read-only):
+
+```bash
+# Single read-write key
+export EVIDENCE_API_KEYS="rw:my-secret-key"
+
+# Multiple keys with different roles
+export EVIDENCE_API_KEYS="rw:ingest-key-for-ci,ro:dashboard-viewer-key"
+```
+
+- **`rw`** keys can read and write (GET + POST).
+- **`ro`** keys can only read (GET). POST requests return `403 Forbidden`.
+- Requests without a valid key return `401 Unauthorized`.
+- When `EVIDENCE_API_KEYS` is empty or unset, authentication is disabled (open access).
+
+Clients authenticate by sending the key as a Bearer token:
+
+```bash
+curl -H "Authorization: Bearer my-secret-key" \
+  http://localhost:8000/api/v1/evidence
+```
+
+The Bazel adapter supports this via `--api-key` or `EVIDENCE_STORE_API_KEY`. The web UI prompts for a key on first 401 and stores it in `localStorage`.
 
 ## Bazel Adapter
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,110 @@
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/nesono/evidence-store/internal/config"
+)
+
+type contextKey string
+
+const roleKey contextKey = "auth_role"
+
+// Role represents the access level of an authenticated request.
+type Role string
+
+const (
+	RoleReadWrite Role = "rw"
+	RoleReadOnly  Role = "ro"
+)
+
+// GetRole returns the authenticated role from the request context.
+// Returns empty string if not authenticated.
+func GetRole(ctx context.Context) Role {
+	if r, ok := ctx.Value(roleKey).(Role); ok {
+		return r
+	}
+	return ""
+}
+
+type keyEntry struct {
+	key      []byte
+	readOnly bool
+}
+
+// Middleware returns an HTTP middleware that validates Bearer tokens
+// against the configured API keys. If keys is empty, the middleware
+// is a no-op (all requests pass through).
+func Middleware(keys []config.APIKey) func(http.Handler) http.Handler {
+	entries := make([]keyEntry, len(keys))
+	for i, k := range keys {
+		entries[i] = keyEntry{key: []byte(k.Key), readOnly: k.ReadOnly}
+	}
+
+	return func(next http.Handler) http.Handler {
+		if len(entries) == 0 {
+			return next
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := extractBearer(r)
+			if token == "" {
+				writeAuthError(w, http.StatusUnauthorized, "missing or invalid Authorization header")
+				return
+			}
+
+			tokenBytes := []byte(token)
+			matched := -1
+			for i, e := range entries {
+				if len(tokenBytes) == len(e.key) && subtle.ConstantTimeCompare(tokenBytes, e.key) == 1 {
+					matched = i
+					break
+				}
+			}
+
+			if matched < 0 {
+				writeAuthError(w, http.StatusUnauthorized, "invalid API key")
+				return
+			}
+
+			entry := entries[matched]
+			if entry.readOnly && !isReadMethod(r.Method) {
+				writeAuthError(w, http.StatusForbidden, "read-only API key cannot perform write operations")
+				return
+			}
+
+			role := RoleReadWrite
+			if entry.readOnly {
+				role = RoleReadOnly
+			}
+			ctx := context.WithValue(r.Context(), roleKey, role)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func extractBearer(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return ""
+	}
+	const prefix = "Bearer "
+	if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return ""
+	}
+	return auth[len(prefix):]
+}
+
+func isReadMethod(method string) bool {
+	return method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
+}
+
+func writeAuthError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,144 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nesono/evidence-store/internal/config"
+)
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		role := GetRole(r.Context())
+		w.Header().Set("X-Auth-Role", string(role))
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestMiddlewareNoKeys(t *testing.T) {
+	// With no keys configured, all requests pass through.
+	mw := Middleware(nil)
+	handler := mw(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evidence", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/evidence", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareMissingHeader(t *testing.T) {
+	keys := []config.APIKey{{Key: "secret", ReadOnly: false}}
+	handler := Middleware(keys)(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evidence", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestMiddlewareInvalidKey(t *testing.T) {
+	keys := []config.APIKey{{Key: "secret", ReadOnly: false}}
+	handler := Middleware(keys)(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evidence", nil)
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestMiddlewareValidRWKey(t *testing.T) {
+	keys := []config.APIKey{{Key: "rw-secret", ReadOnly: false}}
+	handler := Middleware(keys)(okHandler())
+
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		req := httptest.NewRequest(method, "/api/v1/evidence", nil)
+		req.Header.Set("Authorization", "Bearer rw-secret")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code, "method %s should succeed", method)
+		assert.Equal(t, "rw", rec.Header().Get("X-Auth-Role"))
+	}
+}
+
+func TestMiddlewareROKeyAllowsGet(t *testing.T) {
+	keys := []config.APIKey{{Key: "ro-secret", ReadOnly: true}}
+	handler := Middleware(keys)(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evidence", nil)
+	req.Header.Set("Authorization", "Bearer ro-secret")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ro", rec.Header().Get("X-Auth-Role"))
+}
+
+func TestMiddlewareROKeyBlocksPost(t *testing.T) {
+	keys := []config.APIKey{{Key: "ro-secret", ReadOnly: true}}
+	handler := Middleware(keys)(okHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/evidence", nil)
+	req.Header.Set("Authorization", "Bearer ro-secret")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestMiddlewareMultipleKeys(t *testing.T) {
+	keys := []config.APIKey{
+		{Key: "rw-key", ReadOnly: false},
+		{Key: "ro-key", ReadOnly: true},
+	}
+	handler := Middleware(keys)(okHandler())
+
+	// RW key can POST.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/evidence", nil)
+	req.Header.Set("Authorization", "Bearer rw-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// RO key cannot POST.
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/evidence", nil)
+	req.Header.Set("Authorization", "Bearer ro-key")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// RO key can GET.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/evidence", nil)
+	req.Header.Set("Authorization", "Bearer ro-key")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareBearerCaseInsensitive(t *testing.T) {
+	keys := []config.APIKey{{Key: "secret", ReadOnly: false}}
+	handler := Middleware(keys)(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evidence", nil)
+	req.Header.Set("Authorization", "bearer secret")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareNonBearerScheme(t *testing.T) {
+	keys := []config.APIKey{{Key: "secret", ReadOnly: false}}
+	handler := Middleware(keys)(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evidence", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,14 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
+
+// APIKey represents a configured API key with its access role.
+type APIKey struct {
+	Key      string
+	ReadOnly bool
+}
 
 type Config struct {
 	DatabaseURL     string
@@ -13,6 +20,7 @@ type Config struct {
 	MaxPageSize     int
 	MaxBatchSize    int
 	LogLevel        string
+	APIKeys         []APIKey
 }
 
 func Load() (*Config, error) {
@@ -29,7 +37,40 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("EVIDENCE_DATABASE_URL is required")
 	}
 
+	if raw := os.Getenv("EVIDENCE_API_KEYS"); raw != "" {
+		keys, err := ParseAPIKeys(raw)
+		if err != nil {
+			return nil, fmt.Errorf("EVIDENCE_API_KEYS: %w", err)
+		}
+		cfg.APIKeys = keys
+	}
+
 	return cfg, nil
+}
+
+// ParseAPIKeys parses a comma-separated list of "role:key" entries.
+// Valid roles are "rw" (read-write) and "ro" (read-only).
+func ParseAPIKeys(raw string) ([]APIKey, error) {
+	var keys []APIKey
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		role, key, ok := strings.Cut(entry, ":")
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid key entry %q: expected role:key (e.g. rw:my-secret)", entry)
+		}
+		switch role {
+		case "rw":
+			keys = append(keys, APIKey{Key: key, ReadOnly: false})
+		case "ro":
+			keys = append(keys, APIKey{Key: key, ReadOnly: true})
+		default:
+			return nil, fmt.Errorf("invalid role %q in entry %q: must be rw or ro", role, entry)
+		}
+	}
+	return keys, nil
 }
 
 func envOrDefault(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAPIKeysValid(t *testing.T) {
+	keys, err := ParseAPIKeys("rw:my-secret,ro:read-only-key")
+	require.NoError(t, err)
+	assert.Len(t, keys, 2)
+	assert.Equal(t, APIKey{Key: "my-secret", ReadOnly: false}, keys[0])
+	assert.Equal(t, APIKey{Key: "read-only-key", ReadOnly: true}, keys[1])
+}
+
+func TestParseAPIKeysSingle(t *testing.T) {
+	keys, err := ParseAPIKeys("rw:only-key")
+	require.NoError(t, err)
+	assert.Len(t, keys, 1)
+	assert.Equal(t, "only-key", keys[0].Key)
+	assert.False(t, keys[0].ReadOnly)
+}
+
+func TestParseAPIKeysWithSpaces(t *testing.T) {
+	keys, err := ParseAPIKeys("  rw:key1 , ro:key2  ")
+	require.NoError(t, err)
+	assert.Len(t, keys, 2)
+}
+
+func TestParseAPIKeysColonInKey(t *testing.T) {
+	// Key itself can contain colons.
+	keys, err := ParseAPIKeys("rw:my:secret:key")
+	require.NoError(t, err)
+	assert.Equal(t, "my:secret:key", keys[0].Key)
+}
+
+func TestParseAPIKeysEmpty(t *testing.T) {
+	keys, err := ParseAPIKeys("")
+	require.NoError(t, err)
+	assert.Empty(t, keys)
+}
+
+func TestParseAPIKeysInvalidRole(t *testing.T) {
+	_, err := ParseAPIKeys("admin:key")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid role")
+}
+
+func TestParseAPIKeysMissingKey(t *testing.T) {
+	_, err := ParseAPIKeys("rw:")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key entry")
+}
+
+func TestParseAPIKeysNoColon(t *testing.T) {
+	_, err := ParseAPIKeys("justaplainkey")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key entry")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/nesono/evidence-store/internal/api"
+	"github.com/nesono/evidence-store/internal/auth"
 	"github.com/nesono/evidence-store/internal/config"
 	"github.com/nesono/evidence-store/internal/store"
 	"github.com/nesono/evidence-store/web"
@@ -45,6 +46,8 @@ func New(cfg *config.Config, pool *pgxpool.Pool) *Server {
 	inheritanceAPI := api.NewInheritanceHandler(inheritanceStore)
 
 	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(auth.Middleware(cfg.APIKeys))
+
 		r.Post("/evidence", evidenceAPI.Create)
 		r.Post("/evidence/batch", evidenceAPI.CreateBatch)
 		r.Get("/evidence", evidenceAPI.List)

--- a/tests/auth_integration_test.go
+++ b/tests/auth_integration_test.go
@@ -1,0 +1,169 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nesono/evidence-store/internal/config"
+	"github.com/nesono/evidence-store/internal/model"
+	"github.com/nesono/evidence-store/internal/server"
+)
+
+// setupAuthServer creates a test server with API keys configured.
+func setupAuthServer(t *testing.T, keys []config.APIKey) *httptest.Server {
+	t.Helper()
+	cfg := &config.Config{
+		DatabaseURL:     "unused",
+		ListenAddr:      ":0",
+		DefaultPageSize: 100,
+		MaxPageSize:     1000,
+		MaxBatchSize:    1000,
+		LogLevel:        "ERROR",
+		APIKeys:         keys,
+	}
+	_ = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := server.New(cfg, testPool)
+	return httptest.NewServer(srv.Handler())
+}
+
+func doRequest(t *testing.T, method, url, authHeader string, body any) *http.Response {
+	t.Helper()
+	var reqBody *bytes.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reqBody = bytes.NewReader(b)
+	} else {
+		reqBody = bytes.NewReader(nil)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, url, reqBody)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Authentication
+// ---------------------------------------------------------------------------
+
+func TestAuthRequiredForAPI(t *testing.T) {
+	keys := []config.APIKey{{Key: "test-rw-key", ReadOnly: false}}
+	ts := setupAuthServer(t, keys)
+	defer ts.Close()
+
+	// GET without key → 401.
+	resp := doRequest(t, http.MethodGet, ts.URL+"/api/v1/evidence", "", nil)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	resp.Body.Close()
+
+	// GET with valid key → 200.
+	resp = doRequest(t, http.MethodGet, ts.URL+"/api/v1/evidence", "Bearer test-rw-key", nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestAuthInvalidKey(t *testing.T) {
+	keys := []config.APIKey{{Key: "real-key", ReadOnly: false}}
+	ts := setupAuthServer(t, keys)
+	defer ts.Close()
+
+	resp := doRequest(t, http.MethodGet, ts.URL+"/api/v1/evidence", "Bearer wrong-key", nil)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestHealthzBypassesAuth(t *testing.T) {
+	keys := []config.APIKey{{Key: "test-key", ReadOnly: false}}
+	ts := setupAuthServer(t, keys)
+	defer ts.Close()
+
+	// /healthz without key → 200.
+	resp := doRequest(t, http.MethodGet, ts.URL+"/healthz", "", nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestROKeyCanGetButNotPost(t *testing.T) {
+	keys := []config.APIKey{{Key: "ro-key", ReadOnly: true}}
+	ts := setupAuthServer(t, keys)
+	defer ts.Close()
+
+	// GET with RO key → 200.
+	resp := doRequest(t, http.MethodGet, ts.URL+"/api/v1/evidence", "Bearer ro-key", nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// POST with RO key → 403.
+	ev := makeEvidence("org/auth_ro_test", "main", "ref1", "//pkg:test", "ci", model.ResultPass)
+	resp = doRequest(t, http.MethodPost, ts.URL+"/api/v1/evidence", "Bearer ro-key", ev)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestRWKeyCanPost(t *testing.T) {
+	keys := []config.APIKey{{Key: "rw-key", ReadOnly: false}}
+	ts := setupAuthServer(t, keys)
+	defer ts.Close()
+
+	ev := makeEvidence("org/auth_rw_test", "main", "ref1", "//pkg:test", "ci", model.ResultPass)
+	resp := doRequest(t, http.MethodPost, ts.URL+"/api/v1/evidence", "Bearer rw-key", ev)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestNoKeysConfiguredAllowsAll(t *testing.T) {
+	ts := setupAuthServer(t, nil)
+	defer ts.Close()
+
+	// GET without any auth → 200.
+	resp := doRequest(t, http.MethodGet, ts.URL+"/api/v1/evidence", "", nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// POST without any auth → 201.
+	ev := makeEvidence("org/auth_nokeys", "main", "ref1", "//pkg:test", "ci", model.ResultPass)
+	resp = doRequest(t, http.MethodPost, ts.URL+"/api/v1/evidence", "", ev)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestMultipleKeysWithDifferentRoles(t *testing.T) {
+	keys := []config.APIKey{
+		{Key: "admin-key", ReadOnly: false},
+		{Key: "viewer-key", ReadOnly: true},
+	}
+	ts := setupAuthServer(t, keys)
+	defer ts.Close()
+
+	// Admin can POST.
+	ev := makeEvidence("org/auth_multi", "main", "ref1", "//pkg:test", "ci", model.ResultPass)
+	resp := doRequest(t, http.MethodPost, ts.URL+"/api/v1/evidence", "Bearer admin-key", ev)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	// Viewer can GET.
+	resp = doRequest(t, http.MethodGet, ts.URL+"/api/v1/evidence", "Bearer viewer-key", nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Viewer cannot POST.
+	resp = doRequest(t, http.MethodPost, ts.URL+"/api/v1/evidence", "Bearer viewer-key", ev)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	resp.Body.Close()
+}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -87,6 +87,53 @@ function readFormFilters() {
   return filters;
 }
 
+// --- Auth ---
+
+const API_KEY_STORAGE = "evidence_api_key";
+
+function getStoredAPIKey() {
+  return localStorage.getItem(API_KEY_STORAGE) || "";
+}
+
+function setStoredAPIKey(key) {
+  if (key) {
+    localStorage.setItem(API_KEY_STORAGE, key);
+  } else {
+    localStorage.removeItem(API_KEY_STORAGE);
+  }
+  updateAuthUI();
+}
+
+function updateAuthUI() {
+  const btn = document.getElementById("auth-logout");
+  if (btn) btn.hidden = !getStoredAPIKey();
+}
+
+function promptForAPIKey(msg) {
+  const key = prompt(msg || "Enter your API key:");
+  if (key !== null) {
+    setStoredAPIKey(key.trim());
+  }
+  return getStoredAPIKey();
+}
+
+// Wrapper around fetch that attaches Authorization header and handles 401.
+async function apiFetch(url, options = {}) {
+  const key = getStoredAPIKey();
+  if (key) {
+    options.headers = { ...options.headers, Authorization: `Bearer ${key}` };
+  }
+  const resp = await fetch(url, options);
+  if (resp.status === 401) {
+    const newKey = promptForAPIKey("Authentication required. Enter your API key:");
+    if (newKey) {
+      options.headers = { ...options.headers, Authorization: `Bearer ${newKey}` };
+      return fetch(url, options);
+    }
+  }
+  return resp;
+}
+
 // --- API ---
 
 async function fetchEvidence(filters, cursor) {
@@ -100,13 +147,13 @@ async function fetchEvidence(filters, cursor) {
   if (cursor) params.set("cursor", cursor);
   if (!params.has("limit")) params.set("limit", "50");
 
-  const resp = await fetch(`${API_BASE}/evidence?${params}`);
+  const resp = await apiFetch(`${API_BASE}/evidence?${params}`);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
   return resp.json();
 }
 
 async function fetchEvidenceById(id) {
-  const resp = await fetch(`${API_BASE}/evidence/${id}`);
+  const resp = await apiFetch(`${API_BASE}/evidence/${id}`);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
   return resp.json();
 }
@@ -376,7 +423,7 @@ async function submitEvidence(andAnother) {
   btn.setAttribute("aria-busy", "true");
 
   try {
-    const resp = await fetch(`${API_BASE}/evidence`, {
+    const resp = await apiFetch(`${API_BASE}/evidence`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(record),
@@ -751,10 +798,21 @@ function importTemplates(file) {
   reader.readAsText(file);
 }
 
+// --- Auth UI ---
+
+document.getElementById("auth-logout")?.addEventListener("click", () => {
+  setStoredAPIKey("");
+});
+
+document.getElementById("auth-login")?.addEventListener("click", () => {
+  promptForAPIKey("Enter your API key:");
+});
+
 // --- Init ---
 
 (async function init() {
   checkHealth();
+  updateAuthUI();
   refreshTemplateDropdown();
   document.querySelector('#add-form [name="finished_at"]').value = formatTime(new Date().toISOString());
   const filters = readFiltersFromURL();

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -15,6 +15,8 @@
                 <li><a href="#" class="nav-tab active" data-tab="search">Search</a></li>
                 <li><a href="#" class="nav-tab" data-tab="add">Add Result</a></li>
                 <li id="health-status"></li>
+                <li><a href="#" id="auth-login" class="secondary" style="font-size:0.8em">Set API Key</a></li>
+                <li><a href="#" id="auth-logout" class="secondary" style="font-size:0.8em" hidden>Logout</a></li>
             </ul>
         </nav>
     </header>


### PR DESCRIPTION
## Summary
- Add optional Bearer token authentication for all `/api/v1/*` endpoints
- Configure via `EVIDENCE_API_KEYS` env var with `rw` (read-write) and `ro` (read-only) roles
- When unset, auth is disabled — fully backwards compatible
- `/healthz` and static files remain public (no auth required)
- Web UI prompts for API key on 401 and persists it in `localStorage`
- Bazel adapter already sends `Authorization: Bearer` — no adapter changes needed

## Changes
- `internal/auth/middleware.go` — New middleware with constant-time key comparison, role enforcement
- `internal/config/config.go` — Parse `EVIDENCE_API_KEYS` into `[]APIKey` with role/key pairs
- `internal/server/server.go` — Apply auth middleware to `/api/v1` route group
- `web/static/app.js` — `apiFetch()` wrapper attaches Bearer header, handles 401 with key prompt
- `web/static/index.html` — "Set API Key" / "Logout" links in nav bar

## Test plan
- [x] Unit: middleware — no keys (passthrough), missing header (401), invalid key (401), valid rw key (200 on GET+POST), ro key (200 GET, 403 POST), multiple keys, case-insensitive Bearer, non-Bearer scheme
- [x] Unit: config parsing — valid, single, spaces, colon in key, empty, invalid role, missing key, no colon
- [x] Integration: auth required (401 without, 200 with key)
- [x] Integration: invalid key → 401
- [x] Integration: /healthz bypasses auth
- [x] Integration: ro key GET OK, POST 403
- [x] Integration: rw key POST 201
- [x] Integration: no keys configured → open access
- [x] Integration: multiple keys with different roles
- [x] All existing tests still pass (47 total across all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)