### PR TITLE
Add watch mode for automatic test log ingestion

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+# Suppress macOS ld "ignoring duplicate libraries: -lm" warnings from rules_go.
+build --host_action_env=GOFLAGS=-ldflags=-extldflags=-Wl,-no_warn_duplicate_libraries
+build --action_env=GOFLAGS=-ldflags=-extldflags=-Wl,-no_warn_duplicate_libraries

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bazel-*
+.evidence/

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,4 +11,9 @@ go_sdk.from_file(go_mod = "//:go.mod")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
-use_repo(go_deps, "com_github_go_chi_chi_v5", "com_github_golang_migrate_migrate_v4", "com_github_google_uuid", "com_github_jackc_pgx_v5", "com_github_stretchr_testify", "com_github_testcontainers_testcontainers_go")
+go_deps.module(
+    path = "gopkg.in/yaml.v3",
+    sum = "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
+    version = "v3.0.1",
+)
+use_repo(go_deps, "com_github_go_chi_chi_v5", "com_github_golang_migrate_migrate_v4", "com_github_google_uuid", "com_github_jackc_pgx_v5", "com_github_stretchr_testify", "com_github_testcontainers_testcontainers_go", "in_gopkg_yaml_v3")

--- a/README.md
+++ b/README.md
@@ -94,6 +94,32 @@ Or use the dogfood script that does both:
 | `--api-key` | `$EVIDENCE_STORE_API_KEY` | API key |
 | `--dry-run` | `false` | Print records instead of posting |
 
+### Watch Mode (Automatic Ingestion)
+
+The adapter can run as a background watcher that automatically uploads test results after every `bazel test` — no changes to your build workflow needed.
+
+```bash
+# One-time setup: create .evidence/config.yaml in your workspace
+mkdir -p .evidence
+cat > .evidence/config.yaml <<EOF
+api_url: https://evidence.mycompany.com
+tags: [local, dev]
+EOF
+
+# Start the watcher (runs in background)
+bazel run //adapters/bazel/cmd/evidence-bazel -- watch start
+
+# Check status
+bazel run //adapters/bazel/cmd/evidence-bazel -- watch status
+
+# Stop
+bazel run //adapters/bazel/cmd/evidence-bazel -- watch stop
+```
+
+The watcher polls `bazel-testlogs/` every 5 seconds, waits for Bazel to finish (lock released), then uploads only new/changed results. It reads config from `.evidence/config.yaml` and environment variables (`EVIDENCE_STORE_URL`, `EVIDENCE_STORE_API_KEY`). Logs go to `.evidence/watch.log`.
+
+Use `--foreground` with `watch start` to run in the foreground (useful for debugging).
+
 ## API
 
 Base URL: `/api/v1`

--- a/adapters/bazel/cmd/evidence-bazel/BUILD.bazel
+++ b/adapters/bazel/cmd/evidence-bazel/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//adapters/bazel/internal/gitinfo",
         "//adapters/bazel/internal/junitxml",
         "//adapters/bazel/internal/testlogs",
+        "//adapters/bazel/internal/watch",
     ],
 )
 

--- a/adapters/bazel/cmd/evidence-bazel/main.go
+++ b/adapters/bazel/cmd/evidence-bazel/main.go
@@ -208,10 +208,16 @@ func runWatch(args []string) {
 		os.Exit(1)
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+	// When run via "bazel run", the CWD is the runfiles tree.
+	// BUILD_WORKSPACE_DIRECTORY points to the actual workspace root.
+	wd := os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	if wd == "" {
+		var err error
+		wd, err = os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	switch args[0] {

--- a/adapters/bazel/cmd/evidence-bazel/main.go
+++ b/adapters/bazel/cmd/evidence-bazel/main.go
@@ -6,16 +6,25 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/nesono/evidence-store/adapters/bazel/internal/client"
 	"github.com/nesono/evidence-store/adapters/bazel/internal/gitinfo"
 	"github.com/nesono/evidence-store/adapters/bazel/internal/junitxml"
 	"github.com/nesono/evidence-store/adapters/bazel/internal/testlogs"
+	"github.com/nesono/evidence-store/adapters/bazel/internal/watch"
 )
 
 func main() {
+	// Handle "watch" subcommand before flag parsing.
+	if len(os.Args) > 1 && os.Args[1] == "watch" {
+		runWatch(os.Args[2:])
+		return
+	}
+
 	var (
 		apiURL       = flag.String("api-url", envOrDefault("EVIDENCE_STORE_URL", ""), "Evidence Store API base URL (required)")
 		repo         = flag.String("repo", "", "Repository identifier (auto-detected from git remote)")
@@ -191,4 +200,147 @@ func envOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func runWatch(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: evidence-bazel watch <start|stop|status>")
+		os.Exit(1)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "start":
+		runWatchStart(wd, args[1:])
+	case "stop":
+		runWatchStop(wd)
+	case "status":
+		runWatchStatus(wd)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown watch command: %s\nusage: evidence-bazel watch <start|stop|status>\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func runWatchStart(workspaceDir string, args []string) {
+	fs := flag.NewFlagSet("watch start", flag.ExitOnError)
+	foreground := fs.Bool("foreground", false, "Run in foreground (don't daemonize)")
+	fs.Parse(args)
+
+	// Check if already running.
+	if pid, alive := watch.IsRunning(workspaceDir); alive {
+		fmt.Fprintf(os.Stderr, "watcher already running (pid %d)\n", pid)
+		os.Exit(1)
+	}
+
+	cfg, err := watch.LoadConfig(workspaceDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if cfg.APIURL == "" {
+		fmt.Fprintln(os.Stderr, "error: api_url not configured")
+		fmt.Fprintln(os.Stderr, "Set EVIDENCE_STORE_URL or create .evidence/config.yaml with api_url")
+		os.Exit(1)
+	}
+
+	// Daemonize if not foreground.
+	if !*foreground {
+		// Re-exec ourselves with --foreground in the background.
+		exe, err := os.Executable()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := watch.EnsureEvidenceDir(workspaceDir); err != nil {
+			fmt.Fprintf(os.Stderr, "error creating .evidence dir: %v\n", err)
+			os.Exit(1)
+		}
+
+		logFile, err := os.OpenFile(
+			watch.EvidenceDir(workspaceDir)+"/watch.log",
+			os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644,
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error opening log file: %v\n", err)
+			os.Exit(1)
+		}
+
+		proc, err := os.StartProcess(exe, []string{exe, "watch", "start", "--foreground"}, &os.ProcAttr{
+			Dir:   workspaceDir,
+			Env:   os.Environ(),
+			Files: []*os.File{os.Stdin, logFile, logFile},
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error starting daemon: %v\n", err)
+			os.Exit(1)
+		}
+		logFile.Close()
+		proc.Release()
+
+		fmt.Printf("watcher started in background (check .evidence/watch.log for output)\n")
+		return
+	}
+
+	// Foreground mode.
+	if err := watch.EnsureEvidenceDir(workspaceDir); err != nil {
+		fmt.Fprintf(os.Stderr, "error creating .evidence dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	logHandler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(logHandler)
+
+	if err := watch.WritePID(workspaceDir); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing PID file: %v\n", err)
+		os.Exit(1)
+	}
+	defer watch.RemovePID(workspaceDir)
+
+	w, err := watch.NewWatcher(workspaceDir, cfg, logger)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error creating watcher: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle signals for graceful shutdown.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sigCh
+		logger.Info("received shutdown signal")
+		cancel()
+	}()
+
+	if err := w.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "watcher error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runWatchStop(workspaceDir string) {
+	if err := watch.StopWatcher(workspaceDir); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("watcher stopped")
+}
+
+func runWatchStatus(workspaceDir string) {
+	pid, alive := watch.IsRunning(workspaceDir)
+	if alive {
+		fmt.Printf("watcher running (pid %d)\n", pid)
+	} else {
+		fmt.Println("watcher not running")
+	}
 }

--- a/adapters/bazel/go.mod
+++ b/adapters/bazel/go.mod
@@ -2,10 +2,12 @@ module github.com/nesono/evidence-store/adapters/bazel
 
 go 1.25.4
 
-require github.com/stretchr/testify v1.11.1
+require (
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/adapters/bazel/internal/watch/BUILD.bazel
+++ b/adapters/bazel/internal/watch/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "watch",
+    srcs = [
+        "config.go",
+        "daemon.go",
+        "flock_unix.go",
+        "snapshot.go",
+        "watcher.go",
+    ],
+    importpath = "github.com/nesono/evidence-store/adapters/bazel/internal/watch",
+    visibility = ["//adapters/bazel:__subpackages__"],
+    deps = [
+        "//adapters/bazel/internal/client",
+        "//adapters/bazel/internal/gitinfo",
+        "//adapters/bazel/internal/junitxml",
+        "//adapters/bazel/internal/testlogs",
+        "@in_gopkg_yaml_v3//:yaml_v3",
+    ],
+)
+
+go_test(
+    name = "watch_test",
+    srcs = [
+        "config_test.go",
+        "daemon_test.go",
+        "snapshot_test.go",
+    ],
+    embed = [":watch"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/adapters/bazel/internal/watch/config.go
+++ b/adapters/bazel/internal/watch/config.go
@@ -1,0 +1,71 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds watch mode configuration.
+type Config struct {
+	APIURL       string        `yaml:"api_url"`
+	APIKey       string        `yaml:"api_key"`
+	Tags         []string      `yaml:"tags"`
+	PollInterval time.Duration `yaml:"poll_interval"`
+	DebounceWait time.Duration `yaml:"debounce_wait"`
+}
+
+// DefaultConfig returns a config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		PollInterval: 5 * time.Second,
+		DebounceWait: 2 * time.Second,
+	}
+}
+
+// LoadConfig loads config from .evidence/config.yaml in the given workspace
+// directory, then overlays environment variables. Missing file is not an error.
+func LoadConfig(workspaceDir string) (Config, error) {
+	cfg := DefaultConfig()
+
+	configPath := filepath.Join(workspaceDir, ".evidence", "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if err == nil {
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return cfg, fmt.Errorf("parse %s: %w", configPath, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return cfg, fmt.Errorf("read %s: %w", configPath, err)
+	}
+
+	// Environment variables override file config.
+	if v := os.Getenv("EVIDENCE_STORE_URL"); v != "" {
+		cfg.APIURL = v
+	}
+	if v := os.Getenv("EVIDENCE_STORE_API_KEY"); v != "" {
+		cfg.APIKey = v
+	}
+
+	// Ensure defaults for durations if zero (e.g. from partial YAML).
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 5 * time.Second
+	}
+	if cfg.DebounceWait <= 0 {
+		cfg.DebounceWait = 2 * time.Second
+	}
+
+	return cfg, nil
+}
+
+// EvidenceDir returns the .evidence directory path for the given workspace.
+func EvidenceDir(workspaceDir string) string {
+	return filepath.Join(workspaceDir, ".evidence")
+}
+
+// EnsureEvidenceDir creates the .evidence directory if it doesn't exist.
+func EnsureEvidenceDir(workspaceDir string) error {
+	return os.MkdirAll(EvidenceDir(workspaceDir), 0o755)
+}

--- a/adapters/bazel/internal/watch/config_test.go
+++ b/adapters/bazel/internal/watch/config_test.go
@@ -1,0 +1,78 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, cfg.PollInterval)
+	assert.Equal(t, 2*time.Second, cfg.DebounceWait)
+	assert.Empty(t, cfg.APIURL)
+}
+
+func TestLoadConfigFromFile(t *testing.T) {
+	dir := t.TempDir()
+	evidenceDir := filepath.Join(dir, ".evidence")
+	require.NoError(t, os.MkdirAll(evidenceDir, 0o755))
+
+	configYAML := `
+api_url: https://evidence.example.com
+api_key: my-secret
+tags: [local, dev]
+poll_interval: 10s
+debounce_wait: 3s
+`
+	require.NoError(t, os.WriteFile(filepath.Join(evidenceDir, "config.yaml"), []byte(configYAML), 0o644))
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "https://evidence.example.com", cfg.APIURL)
+	assert.Equal(t, "my-secret", cfg.APIKey)
+	assert.Equal(t, []string{"local", "dev"}, cfg.Tags)
+	assert.Equal(t, 10*time.Second, cfg.PollInterval)
+	assert.Equal(t, 3*time.Second, cfg.DebounceWait)
+}
+
+func TestLoadConfigEnvOverridesFile(t *testing.T) {
+	dir := t.TempDir()
+	evidenceDir := filepath.Join(dir, ".evidence")
+	require.NoError(t, os.MkdirAll(evidenceDir, 0o755))
+
+	configYAML := `api_url: https://from-file.example.com`
+	require.NoError(t, os.WriteFile(filepath.Join(evidenceDir, "config.yaml"), []byte(configYAML), 0o644))
+
+	t.Setenv("EVIDENCE_STORE_URL", "https://from-env.example.com")
+	t.Setenv("EVIDENCE_STORE_API_KEY", "env-key")
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "https://from-env.example.com", cfg.APIURL)
+	assert.Equal(t, "env-key", cfg.APIKey)
+}
+
+func TestLoadConfigMissingFileUsesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	// No .evidence/config.yaml — should not error.
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, cfg.PollInterval)
+}
+
+func TestLoadConfigInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	evidenceDir := filepath.Join(dir, ".evidence")
+	require.NoError(t, os.MkdirAll(evidenceDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(evidenceDir, "config.yaml"), []byte("{{invalid"), 0o644))
+
+	_, err := LoadConfig(dir)
+	assert.Error(t, err)
+}

--- a/adapters/bazel/internal/watch/daemon.go
+++ b/adapters/bazel/internal/watch/daemon.go
@@ -1,0 +1,73 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const pidFile = "watch.pid"
+
+// WritePID writes the current process PID to .evidence/watch.pid.
+func WritePID(workspaceDir string) error {
+	path := filepath.Join(EvidenceDir(workspaceDir), pidFile)
+	return os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0o644)
+}
+
+// RemovePID removes the PID file.
+func RemovePID(workspaceDir string) {
+	os.Remove(filepath.Join(EvidenceDir(workspaceDir), pidFile))
+}
+
+// ReadPID reads the PID from .evidence/watch.pid.
+// Returns 0 if the file doesn't exist or is invalid.
+func ReadPID(workspaceDir string) int {
+	data, err := os.ReadFile(filepath.Join(EvidenceDir(workspaceDir), pidFile))
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return pid
+}
+
+// IsRunning checks if a watcher process is alive for the given workspace.
+func IsRunning(workspaceDir string) (int, bool) {
+	pid := ReadPID(workspaceDir)
+	if pid == 0 {
+		return 0, false
+	}
+	// Check if the process is alive by sending signal 0.
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return pid, false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err != nil {
+		// Process doesn't exist — stale PID file.
+		RemovePID(workspaceDir)
+		return pid, false
+	}
+	return pid, true
+}
+
+// StopWatcher sends SIGTERM to the running watcher process.
+func StopWatcher(workspaceDir string) error {
+	pid, alive := IsRunning(workspaceDir)
+	if !alive {
+		return fmt.Errorf("no watcher running (stale pid: %d)", pid)
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process %d: %w", pid, err)
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("send SIGTERM to %d: %w", pid, err)
+	}
+	return nil
+}

--- a/adapters/bazel/internal/watch/daemon_test.go
+++ b/adapters/bazel/internal/watch/daemon_test.go
@@ -1,0 +1,62 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteAndReadPID(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".evidence"), 0o755))
+
+	require.NoError(t, WritePID(dir))
+	pid := ReadPID(dir)
+	assert.Equal(t, os.Getpid(), pid)
+}
+
+func TestReadPIDMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	pid := ReadPID(dir)
+	assert.Equal(t, 0, pid)
+}
+
+func TestIsRunningCurrentProcess(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".evidence"), 0o755))
+	require.NoError(t, WritePID(dir))
+
+	pid, alive := IsRunning(dir)
+	assert.True(t, alive)
+	assert.Equal(t, os.Getpid(), pid)
+}
+
+func TestIsRunningStalePID(t *testing.T) {
+	dir := t.TempDir()
+	evidenceDir := filepath.Join(dir, ".evidence")
+	require.NoError(t, os.MkdirAll(evidenceDir, 0o755))
+
+	// Write a PID that definitely doesn't exist.
+	stalePID := 99999999
+	require.NoError(t, os.WriteFile(filepath.Join(evidenceDir, "watch.pid"), []byte(strconv.Itoa(stalePID)), 0o644))
+
+	pid, alive := IsRunning(dir)
+	assert.False(t, alive)
+	assert.Equal(t, stalePID, pid)
+
+	// Stale PID file should be cleaned up.
+	assert.Equal(t, 0, ReadPID(dir))
+}
+
+func TestRemovePID(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".evidence"), 0o755))
+	require.NoError(t, WritePID(dir))
+
+	RemovePID(dir)
+	assert.Equal(t, 0, ReadPID(dir))
+}

--- a/adapters/bazel/internal/watch/flock_unix.go
+++ b/adapters/bazel/internal/watch/flock_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package watch
+
+import (
+	"os"
+	"syscall"
+)
+
+func syscallFlock(f *os.File, how int) error {
+	return syscall.Flock(int(f.Fd()), how)
+}
+
+// isFileLocked tries to acquire an exclusive lock on the file.
+// Returns true if the file is locked (Bazel is running).
+func isFileLocked(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false // file doesn't exist = not locked
+	}
+	defer f.Close()
+
+	// Try a non-blocking exclusive lock.
+	err = syscallFlock(f, syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		return true // lock held by another process (Bazel)
+	}
+	// We got the lock — Bazel is not running. Release it.
+	syscallFlock(f, syscall.LOCK_UN)
+	return false
+}

--- a/adapters/bazel/internal/watch/snapshot.go
+++ b/adapters/bazel/internal/watch/snapshot.go
@@ -1,0 +1,79 @@
+package watch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Snapshot tracks the state of uploaded test.xml files so we only upload new results.
+type Snapshot struct {
+	// UploadedAt is when the last upload cycle completed.
+	UploadedAt time.Time `json:"uploaded_at"`
+	// Files maps test.xml absolute paths to their mtime at time of upload.
+	Files map[string]time.Time `json:"files"`
+}
+
+const snapshotFile = "last-upload.json"
+
+// LoadSnapshot reads the snapshot from .evidence/last-upload.json.
+// Returns an empty snapshot if the file doesn't exist.
+func LoadSnapshot(workspaceDir string) (*Snapshot, error) {
+	path := filepath.Join(EvidenceDir(workspaceDir), snapshotFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Snapshot{Files: make(map[string]time.Time)}, nil
+		}
+		return nil, err
+	}
+	var snap Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		// Corrupted file — start fresh.
+		return &Snapshot{Files: make(map[string]time.Time)}, nil
+	}
+	if snap.Files == nil {
+		snap.Files = make(map[string]time.Time)
+	}
+	return &snap, nil
+}
+
+// Save writes the snapshot to .evidence/last-upload.json.
+func (s *Snapshot) Save(workspaceDir string) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(EvidenceDir(workspaceDir), snapshotFile)
+	return os.WriteFile(path, data, 0o644)
+}
+
+// ChangedFiles returns the list of test.xml paths that are new or have a
+// newer mtime than what was recorded in the snapshot.
+func (s *Snapshot) ChangedFiles(xmlPaths []string) ([]string, error) {
+	var changed []string
+	for _, p := range xmlPaths {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue // file disappeared — skip
+		}
+		mtime := info.ModTime()
+		if prev, ok := s.Files[p]; !ok || mtime.After(prev) {
+			changed = append(changed, p)
+		}
+	}
+	return changed, nil
+}
+
+// Record updates the snapshot with the current mtimes for the given paths.
+func (s *Snapshot) Record(xmlPaths []string) {
+	s.UploadedAt = time.Now().UTC()
+	for _, p := range xmlPaths {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		s.Files[p] = info.ModTime()
+	}
+}

--- a/adapters/bazel/internal/watch/snapshot_test.go
+++ b/adapters/bazel/internal/watch/snapshot_test.go
@@ -1,0 +1,98 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotLoadEmpty(t *testing.T) {
+	dir := t.TempDir()
+	snap, err := LoadSnapshot(dir)
+	require.NoError(t, err)
+	assert.NotNil(t, snap.Files)
+	assert.Empty(t, snap.Files)
+}
+
+func TestSnapshotSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".evidence"), 0o755))
+
+	snap := &Snapshot{
+		UploadedAt: time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC),
+		Files: map[string]time.Time{
+			"/path/to/test.xml": time.Date(2026, 4, 15, 9, 59, 0, 0, time.UTC),
+		},
+	}
+	require.NoError(t, snap.Save(dir))
+
+	loaded, err := LoadSnapshot(dir)
+	require.NoError(t, err)
+	assert.Equal(t, snap.UploadedAt.Unix(), loaded.UploadedAt.Unix())
+	assert.Len(t, loaded.Files, 1)
+}
+
+func TestSnapshotChangedFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two test.xml files.
+	file1 := filepath.Join(dir, "test1.xml")
+	file2 := filepath.Join(dir, "test2.xml")
+	require.NoError(t, os.WriteFile(file1, []byte("<xml/>"), 0o644))
+	require.NoError(t, os.WriteFile(file2, []byte("<xml/>"), 0o644))
+
+	info1, _ := os.Stat(file1)
+	info2, _ := os.Stat(file2)
+
+	// Snapshot knows about file1 with its current mtime.
+	snap := &Snapshot{
+		Files: map[string]time.Time{
+			file1: info1.ModTime(),
+		},
+	}
+
+	// file2 is new, file1 is unchanged.
+	changed, err := snap.ChangedFiles([]string{file1, file2})
+	require.NoError(t, err)
+	assert.Len(t, changed, 1)
+	assert.Equal(t, file2, changed[0])
+
+	// After touching file1, both should show as changed.
+	time.Sleep(10 * time.Millisecond) // ensure mtime difference
+	require.NoError(t, os.WriteFile(file1, []byte("<xml>updated</xml>"), 0o644))
+	info1after, _ := os.Stat(file1)
+	_ = info2 // not changed
+
+	// Re-check: file1 now has newer mtime, file2 still unknown.
+	changed, err = snap.ChangedFiles([]string{file1, file2})
+	require.NoError(t, err)
+	assert.Len(t, changed, 2)
+	_ = info1after
+}
+
+func TestSnapshotRecord(t *testing.T) {
+	dir := t.TempDir()
+	file1 := filepath.Join(dir, "test.xml")
+	require.NoError(t, os.WriteFile(file1, []byte("<xml/>"), 0o644))
+
+	snap := &Snapshot{Files: make(map[string]time.Time)}
+	snap.Record([]string{file1})
+
+	assert.Contains(t, snap.Files, file1)
+	assert.False(t, snap.UploadedAt.IsZero())
+}
+
+func TestSnapshotCorruptedFileStartsFresh(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".evidence"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".evidence", "last-upload.json"), []byte("not json"), 0o644))
+
+	snap, err := LoadSnapshot(dir)
+	require.NoError(t, err)
+	assert.NotNil(t, snap.Files)
+	assert.Empty(t, snap.Files)
+}

--- a/adapters/bazel/internal/watch/watcher.go
+++ b/adapters/bazel/internal/watch/watcher.go
@@ -1,0 +1,310 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nesono/evidence-store/adapters/bazel/internal/client"
+	"github.com/nesono/evidence-store/adapters/bazel/internal/gitinfo"
+	"github.com/nesono/evidence-store/adapters/bazel/internal/junitxml"
+	"github.com/nesono/evidence-store/adapters/bazel/internal/testlogs"
+)
+
+// Watcher polls the bazel-testlogs directory and uploads new test results.
+type Watcher struct {
+	workspaceDir string
+	testlogsDir  string
+	cfg          Config
+	logger       *slog.Logger
+}
+
+// NewWatcher creates a watcher for the given workspace directory.
+func NewWatcher(workspaceDir string, cfg Config, logger *slog.Logger) (*Watcher, error) {
+	testlogsDir, err := resolveTestlogsDir(workspaceDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve testlogs dir: %w", err)
+	}
+
+	return &Watcher{
+		workspaceDir: workspaceDir,
+		testlogsDir:  testlogsDir,
+		cfg:          cfg,
+		logger:       logger,
+	}, nil
+}
+
+// Run starts the polling loop. It blocks until ctx is cancelled.
+func (w *Watcher) Run(ctx context.Context) error {
+	w.logger.Info("watcher started",
+		"workspace", w.workspaceDir,
+		"testlogs", w.testlogsDir,
+		"poll_interval", w.cfg.PollInterval,
+		"api_url", w.cfg.APIURL,
+	)
+
+	ticker := time.NewTicker(w.cfg.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("watcher stopped")
+			return nil
+		case <-ticker.C:
+			if err := w.poll(ctx); err != nil {
+				w.logger.Error("poll cycle failed", "error", err)
+			}
+		}
+	}
+}
+
+// poll runs a single check-and-upload cycle.
+func (w *Watcher) poll(ctx context.Context) error {
+	// Scan testlogs directory for test.xml files.
+	entries, err := testlogs.Scan(w.testlogsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // testlogs dir doesn't exist yet — no tests run
+		}
+		return fmt.Errorf("scan testlogs: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Load the snapshot to see what we've already uploaded.
+	snap, err := LoadSnapshot(w.workspaceDir)
+	if err != nil {
+		return fmt.Errorf("load snapshot: %w", err)
+	}
+
+	// Find test.xml files that changed since last upload.
+	var allPaths []string
+	for _, e := range entries {
+		allPaths = append(allPaths, e.XMLPath)
+	}
+	changedPaths, err := snap.ChangedFiles(allPaths)
+	if err != nil {
+		return fmt.Errorf("check changed files: %w", err)
+	}
+	if len(changedPaths) == 0 {
+		return nil
+	}
+
+	w.logger.Info("detected new test results", "count", len(changedPaths))
+
+	// Wait for Bazel to finish (lock file released).
+	if err := w.waitForBazelIdle(ctx); err != nil {
+		return fmt.Errorf("wait for bazel: %w", err)
+	}
+
+	// Record snapshot time BEFORE reading files.
+	snapshotTime := time.Now().UTC()
+
+	// Build a set of changed paths for quick lookup.
+	changedSet := make(map[string]struct{}, len(changedPaths))
+	for _, p := range changedPaths {
+		changedSet[p] = struct{}{}
+	}
+
+	// Filter entries to only changed ones, and read test.xml data into memory.
+	var changedEntries []testlogs.TestLogEntry
+	type parsedResult struct {
+		entry    testlogs.TestLogEntry
+		result   string
+		duration float64
+	}
+	var results []parsedResult
+
+	for _, entry := range entries {
+		if _, ok := changedSet[entry.XMLPath]; !ok {
+			continue
+		}
+		changedEntries = append(changedEntries, entry)
+
+		result, duration, err := w.parseEntry(entry)
+		if err != nil {
+			w.logger.Warn("skipping unparseable entry", "target", entry.BazelTarget, "error", err)
+			continue
+		}
+		results = append(results, parsedResult{entry: entry, result: result, duration: duration})
+	}
+
+	if len(results) == 0 {
+		return nil
+	}
+
+	// Auto-detect git info.
+	info, err := gitinfo.Detect()
+	if err != nil {
+		w.logger.Warn("could not detect git info", "error", err)
+		return nil // can't upload without repo/ref
+	}
+	source := gitinfo.DetectSource()
+
+	// Build evidence records.
+	records := make([]client.EvidenceRecord, 0, len(results))
+	for _, r := range results {
+		metadata := map[string]any{
+			"duration_s":        r.duration,
+			"result_was_cached": r.entry.WasCached,
+		}
+		if len(w.cfg.Tags) > 0 {
+			metadata["tags"] = w.cfg.Tags
+		}
+
+		records = append(records, client.EvidenceRecord{
+			Repo:         info.Repo,
+			Branch:       info.Branch,
+			RCSRef:       info.Ref,
+			ProcedureRef: r.entry.BazelTarget,
+			EvidenceType: "bazel",
+			Source:       source,
+			Result:       r.result,
+			FinishedAt:   snapshotTime.Format(time.RFC3339),
+			Metadata:     metadata,
+		})
+	}
+
+	// Upload.
+	if w.cfg.APIURL == "" {
+		w.logger.Warn("api_url not configured, skipping upload")
+		return nil
+	}
+
+	var opts []client.Option
+	if w.cfg.APIKey != "" {
+		opts = append(opts, client.WithAPIKey(w.cfg.APIKey))
+	}
+	c := client.New(w.cfg.APIURL, opts...)
+
+	uploadCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	responses, err := c.PostBatch(uploadCtx, records)
+	if err != nil {
+		w.logger.Error("upload failed", "error", err)
+		return nil // don't fail the poll cycle — try again next time
+	}
+
+	var created, failed int
+	for _, resp := range responses {
+		for _, r := range resp.Results {
+			if r.Status == "created" {
+				created++
+			} else {
+				failed++
+			}
+		}
+	}
+	w.logger.Info("upload complete", "created", created, "failed", failed)
+
+	// Record the uploaded files in the snapshot.
+	var uploadedPaths []string
+	for _, r := range results {
+		uploadedPaths = append(uploadedPaths, r.entry.XMLPath)
+	}
+	snap.Record(uploadedPaths)
+	snap.UploadedAt = snapshotTime
+	if err := snap.Save(w.workspaceDir); err != nil {
+		w.logger.Error("failed to save snapshot", "error", err)
+	}
+
+	return nil
+}
+
+// parseEntry reads and parses a single test entry, returning result and duration.
+func (w *Watcher) parseEntry(entry testlogs.TestLogEntry) (string, float64, error) {
+	f, err := os.Open(entry.XMLPath)
+	if err != nil {
+		return "", 0, fmt.Errorf("open %s: %w", entry.XMLPath, err)
+	}
+	defer f.Close()
+
+	ts, err := junitxml.Parse(f)
+	if err != nil {
+		return "", 0, fmt.Errorf("parse %s: %w", entry.XMLPath, err)
+	}
+
+	if ts != nil {
+		result, duration := junitxml.AggregateResult(ts)
+		return result, duration, nil
+	}
+
+	// Empty XML stub — try test.log.
+	if result, ok := testlogs.ResultFromLog(entry.LogPath); ok {
+		return result, 0, nil
+	}
+
+	return "", 0, fmt.Errorf("empty test.xml and unparseable test.log for %s", entry.BazelTarget)
+}
+
+// waitForBazelIdle waits until the Bazel workspace lock is released.
+// Uses the output_base/lock file as a signal that Bazel is running.
+func (w *Watcher) waitForBazelIdle(ctx context.Context) error {
+	lockPath, err := w.bazelLockPath()
+	if err != nil {
+		// Can't determine lock path — just wait the debounce time and hope.
+		w.logger.Warn("cannot determine bazel lock path, using debounce wait", "error", err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(w.cfg.DebounceWait):
+			return nil
+		}
+	}
+
+	w.logger.Debug("waiting for bazel lock release", "lock", lockPath)
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if !isFileLocked(lockPath) {
+				return nil
+			}
+		}
+	}
+}
+
+// bazelLockPath returns the path to the Bazel output base lock file.
+func (w *Watcher) bazelLockPath() (string, error) {
+	cmd := exec.Command("bazel", "info", "output_base")
+	cmd.Dir = w.workspaceDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("bazel info output_base: %w", err)
+	}
+	return filepath.Join(strings.TrimSpace(string(out)), "lock"), nil
+}
+
+// isFileLocked is implemented in flock_unix.go / flock_windows.go.
+
+// resolveTestlogsDir finds the testlogs directory for the workspace.
+func resolveTestlogsDir(workspaceDir string) (string, error) {
+	// First try "bazel info bazel-testlogs".
+	cmd := exec.Command("bazel", "info", "bazel-testlogs")
+	cmd.Dir = workspaceDir
+	out, err := cmd.Output()
+	if err == nil {
+		return strings.TrimSpace(string(out)), nil
+	}
+
+	// Fall back to the conventional symlink.
+	testlogsDir := filepath.Join(workspaceDir, "bazel-testlogs")
+	if _, err := os.Lstat(testlogsDir); err == nil {
+		return testlogsDir, nil
+	}
+
+	return testlogsDir, nil // return default path even if it doesn't exist yet
+}

--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -8,7 +8,9 @@ go_library(
     deps = [
         "//internal/config",
         "//internal/migrate",
+        "//internal/retention",
         "//internal/server",
+        "//internal/store",
         "@com_github_jackc_pgx_v5//pgxpool",
     ],
 )

--- a/internal/auth/BUILD.bazel
+++ b/internal/auth/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "auth",
+    srcs = ["middleware.go"],
+    importpath = "github.com/nesono/evidence-store/internal/auth",
+    visibility = ["//:__subpackages__"],
+    deps = ["//internal/config"],
+)
+
+go_test(
+    name = "auth_test",
+    srcs = ["middleware_test.go"],
+    embed = [":auth"],
+    deps = [
+        "//internal/config",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/internal/config/BUILD.bazel
+++ b/internal/config/BUILD.bazel
@@ -1,8 +1,18 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "config",
     srcs = ["config.go"],
     importpath = "github.com/nesono/evidence-store/internal/config",
     visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    embed = [":config"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/internal/model/BUILD.bazel
+++ b/internal/model/BUILD.bazel
@@ -13,7 +13,10 @@ go_library(
 
 go_test(
     name = "model_test",
-    srcs = ["evidence_test.go"],
+    srcs = [
+        "evidence_test.go",
+        "flextime_test.go",
+    ],
     embed = [":model"],
     deps = [
         "@com_github_stretchr_testify//assert",

--- a/internal/retention/BUILD.bazel
+++ b/internal/retention/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "retention",
+    srcs = [
+        "config.go",
+        "evaluator.go",
+        "worker.go",
+    ],
+    importpath = "github.com/nesono/evidence-store/internal/retention",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/model",
+        "//internal/store",
+        "@com_github_google_uuid//:uuid",
+        "@in_gopkg_yaml_v3//:yaml_v3",
+    ],
+)
+
+go_test(
+    name = "retention_test",
+    srcs = [
+        "config_test.go",
+        "evaluator_test.go",
+        "worker_test.go",
+    ],
+    embed = [":retention"],
+    deps = [
+        "//internal/model",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/internal/server/BUILD.bazel
+++ b/internal/server/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/api",
+        "//internal/auth",
         "//internal/config",
         "//internal/store",
         "//web",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -2,7 +2,13 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "tests_test",
-    srcs = ["integration_test.go"],
+    srcs = [
+        "auth_integration_test.go",
+        "integration_test.go",
+        "regex_search_test.go",
+        "retention_integration_test.go",
+        "utc_normalization_test.go",
+    ],
     data = ["//migrations"],
     tags = [
         "exclusive",
@@ -12,7 +18,9 @@ go_test(
         "//internal/config",
         "//internal/migrate",
         "//internal/model",
+        "//internal/retention",
         "//internal/server",
+        "//internal/store",
         "@com_github_google_uuid//:uuid",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_stretchr_testify//assert",


### PR DESCRIPTION
## Summary
- Add `evidence-bazel watch start|stop|status` subcommand for automatic background ingestion
- Polls `bazel-testlogs/` every 5s, waits for Bazel lock release, then uploads only new/changed results
- Snapshots files into memory before upload to avoid races with subsequent `bazel test` runs
- Tracks uploaded mtimes in `.evidence/last-upload.json` for deduplication
- Config via `.evidence/config.yaml` and/or environment variables
- Daemonizes by default; `--foreground` flag for debugging
- Logs to `.evidence/watch.log`

## Race condition handling
1. **Overlapping test runs**: waits for Bazel lock file release before scanning
2. **New run during upload**: files read into memory at snapshot time; new runs picked up next cycle
3. **No blocking**: never holds the Bazel lock; developer workflow is unaffected

## New files
- `adapters/bazel/internal/watch/` — config, snapshot/dedup, daemon management, watcher core, flock
- Updated `adapters/bazel/cmd/evidence-bazel/main.go` — `watch` subcommand dispatch + daemon logic

## Test plan
- [x] Unit: config loading (defaults, file, env override, missing file, invalid YAML) — 5 tests
- [x] Unit: snapshot (load empty, save/load roundtrip, changed files detection, record, corrupted file) — 5 tests
- [x] Unit: daemon (write/read PID, missing file, is-running current process, stale PID cleanup, remove) — 5 tests
- [x] All existing adapter tests pass (client, gitinfo, junitxml, testlogs)
- [x] All main project tests pass (47 tests)
- [x] `bazel run //:gazelle` — BUILD files regenerated

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)