### PR TITLE
Handle file races in watcher during rapid test loops

### DIFF
--- a/adapters/bazel/internal/testlogs/scan.go
+++ b/adapters/bazel/internal/testlogs/scan.go
@@ -33,6 +33,11 @@ func Scan(testlogsDir string) ([]TestLogEntry, error) {
 
 	err = filepath.Walk(absDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			// Bazel may delete/move test output dirs mid-walk when a new
+			// test run starts. Treat "not exist" as transient and skip.
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 		if info.IsDir() || info.Name() != "test.xml" {

--- a/adapters/bazel/internal/watch/watcher.go
+++ b/adapters/bazel/internal/watch/watcher.go
@@ -130,6 +130,12 @@ func (w *Watcher) poll(ctx context.Context) error {
 
 		result, duration, err := w.parseEntry(entry)
 		if err != nil {
+			// If the file vanished between scan and read, a new Bazel run
+			// started and clobbered it. Expected; we'll pick it up next cycle.
+			if os.IsNotExist(err) {
+				w.logger.Debug("test file disappeared mid-cycle", "target", entry.BazelTarget)
+				continue
+			}
 			w.logger.Warn("skipping unparseable entry", "target", entry.BazelTarget, "error", err)
 			continue
 		}


### PR DESCRIPTION
## Summary
- Swallow `ENOENT` errors in `filepath.Walk` when Bazel deletes test output directories mid-scan
- Downgrade the "test.xml disappeared between scan and read" message from WARN to DEBUG

## Context
When running `bzt //...` in a loop, the watcher's poll cycle races with Bazel clobbering the testlogs tree. The two resulting errors were harmless but noisy:

1. `scan testlogs: walk testlogs: lstat ... test.outputs: no such file or directory` — failed the whole poll cycle
2. `skipping unparseable entry: open test.xml: no such file or directory` — just noise; the file is gone because a newer run started

Both are now handled gracefully: the missing entries are skipped and will be picked up on the next cycle.

## Test plan
- [x] `bazel test //adapters/bazel/internal/testlogs:testlogs_test //adapters/bazel/internal/watch:watch_test` passes
- [ ] Run `bzt //...` in a tight loop with the watcher active and verify no spurious errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)