### PR TITLE
Poll /healthz periodically so connection status updates

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -158,10 +158,12 @@ async function fetchEvidenceById(id) {
   return resp.json();
 }
 
+const HEALTH_POLL_MS = 5000;
+
 async function checkHealth() {
   const el = document.getElementById("health-status");
   try {
-    const resp = await fetch("/healthz");
+    const resp = await fetch("/healthz", { cache: "no-store" });
     if (resp.ok) {
       el.innerHTML = `<span class="health-dot health-ok"></span> Connected`;
     } else {
@@ -170,6 +172,14 @@ async function checkHealth() {
   } catch {
     el.innerHTML = `<span class="health-dot health-fail"></span> Offline`;
   }
+}
+
+function startHealthPolling() {
+  checkHealth();
+  setInterval(checkHealth, HEALTH_POLL_MS);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") checkHealth();
+  });
 }
 
 // --- Rendering ---
@@ -811,7 +821,7 @@ document.getElementById("auth-login")?.addEventListener("click", () => {
 // --- Init ---
 
 (async function init() {
-  checkHealth();
+  startHealthPolling();
   updateAuthUI();
   refreshTemplateDropdown();
   document.querySelector('#add-form [name="finished_at"]').value = formatTime(new Date().toISOString());


### PR DESCRIPTION
## Summary
- Health indicator only ran `checkHealth()` once at page load, so it never updated after the backend went down (#16)
- Now polls `/healthz` every 5 s and re-checks on `visibilitychange` so a backgrounded tab catches up on return

## Test plan
- [x] Verified backend returns 200 (both up) → **Connected**
- [x] Verified backend returns 503 (db stopped) → **Unhealthy**
- [x] Verified fetch fails (app stopped) → **Offline**
- [x] Checked `/healthz` is cache-busted with `cache: "no-store"`

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)