### PR TITLE
Add Renovate config for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":timezone(Europe/Berlin)"
+  ],
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 0,
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["gomod"],
+      "groupName": "Go minor + patch",
+      "automerge": false
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions minor + patch",
+      "automerge": false
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "groupName": "Docker minor + patch",
+      "automerge": false
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["bazel-module"],
+      "groupName": "Bazel minor + patch",
+      "automerge": false
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json` extending `config:recommended` with semantic commits
- Covers **gomod** (root + `adapters/bazel`), **bazel-module** (`MODULE.bazel`), **dockerfile**, **docker-compose**, and **github-actions**
- Groups minor+patch per ecosystem → low PR volume; majors gated behind the Renovate Dependency Dashboard
- Runs weekly (Monday mornings, Europe/Berlin), security alerts fire any time
- Validated with `renovate-config-validator`

## Follow-up required
The Renovate GitHub App must be installed on `nesono/evidence_store` before this config has any effect:
https://github.com/apps/renovate

Once installed, Renovate will open an onboarding PR and then start creating grouped update PRs on schedule.

## Test plan
- [x] `renovate-config-validator renovate.json` passes
- [ ] After install, confirm the Renovate onboarding PR shows the expected ecosystems detected

Closes #21
Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)