### PR TITLE
Show full match count in result summary

### DIFF
--- a/internal/api/evidence.go
+++ b/internal/api/evidence.go
@@ -227,8 +227,10 @@ func (h *EvidenceHandler) List(w http.ResponseWriter, r *http.Request) {
 	response := struct {
 		Records    []model.EvidenceResponse `json:"records"`
 		NextCursor *string                  `json:"next_cursor,omitempty"`
+		Total      *int64                   `json:"total,omitempty"`
 	}{
 		NextCursor: result.NextCursor,
+		Total:      result.Total,
 	}
 
 	inherited := false

--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -89,6 +89,7 @@ type ListParams struct {
 type ListResult struct {
 	Records    []model.Evidence `json:"records"`
 	NextCursor *string          `json:"next_cursor,omitempty"`
+	Total      *int64           `json:"total,omitempty"`
 }
 
 func (s *EvidenceStore) List(ctx context.Context, params ListParams) (*ListResult, error) {
@@ -165,6 +166,22 @@ func (s *EvidenceStore) List(ctx context.Context, params ListParams) (*ListResul
 			where = append(where, fmt.Sprintf("metadata->>'notes' = %s", arg(val)))
 		}
 	}
+	// Count matching records before adding pagination clauses. Only done on
+	// the first page (no cursor) — subsequent pages keep the total from the
+	// first call so we don't recount on every "next page" click.
+	var total *int64
+	if params.Cursor == nil {
+		countQuery := "SELECT COUNT(*) FROM evidence"
+		if len(where) > 0 {
+			countQuery += " WHERE " + strings.Join(where, " AND ")
+		}
+		var n int64
+		if err := s.pool.QueryRow(ctx, countQuery, args...).Scan(&n); err != nil {
+			return nil, fmt.Errorf("count evidence: %w", err)
+		}
+		total = &n
+	}
+
 	if params.Cursor != nil {
 		where = append(where, fmt.Sprintf("(ingested_at, id) > (%s, %s)", arg(params.Cursor.IngestedAt), arg(params.Cursor.ID)))
 	}
@@ -194,7 +211,7 @@ func (s *EvidenceStore) List(ctx context.Context, params ListParams) (*ListResul
 		return nil, fmt.Errorf("iterate evidence rows: %w", err)
 	}
 
-	result := &ListResult{}
+	result := &ListResult{Total: total}
 	if len(records) > params.Limit {
 		last := records[params.Limit-1]
 		cursor := EncodeCursor(last.IngestedAt, last.ID)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -360,6 +360,8 @@ func TestListEvidencePagination(t *testing.T) {
 	page1 := decodeJSON[listResponse](t, resp)
 	assert.Len(t, page1.Records, 2)
 	require.NotNil(t, page1.NextCursor, "expected a next_cursor for page 1")
+	require.NotNil(t, page1.Total, "expected total on first page")
+	assert.Equal(t, int64(5), *page1.Total, "total should reflect full filtered count")
 
 	// Fetch page 2.
 	resp = getJSON(t, fmt.Sprintf("/api/v1/evidence?repo=%s&limit=2&cursor=%s", repo, *page1.NextCursor))
@@ -368,6 +370,7 @@ func TestListEvidencePagination(t *testing.T) {
 	page2 := decodeJSON[listResponse](t, resp)
 	assert.Len(t, page2.Records, 2)
 	require.NotNil(t, page2.NextCursor, "expected a next_cursor for page 2")
+	assert.Nil(t, page2.Total, "total should only be returned on first page")
 
 	// Fetch page 3 (last page, should have 1 record).
 	resp = getJSON(t, fmt.Sprintf("/api/v1/evidence?repo=%s&limit=2&cursor=%s", repo, *page2.NextCursor))
@@ -376,6 +379,7 @@ func TestListEvidencePagination(t *testing.T) {
 	page3 := decodeJSON[listResponse](t, resp)
 	assert.Len(t, page3.Records, 1)
 	assert.Nil(t, page3.NextCursor, "expected no next_cursor on last page")
+	assert.Nil(t, page3.Total, "total should only be returned on first page")
 
 	// Verify no overlap between pages.
 	allIDs := make(map[uuid.UUID]bool)
@@ -384,6 +388,26 @@ func TestListEvidencePagination(t *testing.T) {
 		allIDs[r.ID] = true
 	}
 	assert.Len(t, allIDs, 5)
+}
+
+func TestListEvidenceTotalWhenSinglePage(t *testing.T) {
+	repo := "org/single_page_" + uuid.New().String()[:8]
+
+	for range 3 {
+		ev := makeEvidence(repo, "main", "qqq111", "//pkg:only_test", "ci", model.ResultPass)
+		resp := postJSON(t, "/api/v1/evidence", ev)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	resp := getJSON(t, fmt.Sprintf("/api/v1/evidence?repo=%s&limit=50", repo))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	page := decodeJSON[listResponse](t, resp)
+	assert.Len(t, page.Records, 3)
+	assert.Nil(t, page.NextCursor, "no next cursor when results fit in one page")
+	require.NotNil(t, page.Total)
+	assert.Equal(t, int64(3), *page.Total)
 }
 
 // ---------------------------------------------------------------------------
@@ -573,6 +597,7 @@ func TestHealthCheck(t *testing.T) {
 type listResponse struct {
 	Records    []model.EvidenceResponse `json:"records"`
 	NextCursor *string                  `json:"next_cursor"`
+	Total      *int64                   `json:"total"`
 }
 
 type inheritanceListResponse struct {

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -7,6 +7,7 @@ const DATETIME_FIELDS = ["finished_after", "finished_before"];
 
 let cursorStack = [];
 let currentCursor = null;
+let currentTotal = null;
 
 // --- URL State ---
 
@@ -236,10 +237,18 @@ function renderTable(records) {
   `).join("");
 }
 
-function renderSummary(count, hasMore) {
+function renderSummary(pageCount, total, hasMore) {
   const el = document.getElementById("results-summary");
+  if (total !== null && total !== undefined) {
+    if (total === pageCount) {
+      el.textContent = `${total} record${total !== 1 ? "s" : ""}`;
+    } else {
+      el.textContent = `showing ${pageCount} of ${total} records`;
+    }
+    return;
+  }
   const suffix = hasMore ? "+" : "";
-  el.textContent = `${count}${suffix} record${count !== 1 ? "s" : ""}`;
+  el.textContent = `${pageCount}${suffix} record${pageCount !== 1 ? "s" : ""}`;
 }
 
 function renderPagination(nextCursor) {
@@ -293,14 +302,23 @@ async function doSearch(filters, cursor) {
   const tbody = document.getElementById("results-body");
   tbody.innerHTML = `<tr><td colspan="9" class="empty-state">Loading...</td></tr>`;
 
+  // Fresh first-page fetch invalidates any previously cached total.
+  if (!cursor) {
+    currentTotal = null;
+  }
+
   try {
     const data = await fetchEvidence(filters, cursor);
     renderTable(data.records);
-    renderSummary(data.records ? data.records.length : 0, !!data.next_cursor);
+    // The API only returns `total` on the first page; preserve it across subsequent page fetches.
+    if (data.total !== undefined && data.total !== null) {
+      currentTotal = data.total;
+    }
+    renderSummary(data.records ? data.records.length : 0, currentTotal, !!data.next_cursor);
     renderPagination(data.next_cursor || null);
   } catch (err) {
     tbody.innerHTML = `<tr><td colspan="9" class="empty-state">Error: ${esc(err.message)}</td></tr>`;
-    renderSummary(0, false);
+    renderSummary(0, null, false);
     renderPagination(null);
   }
 }


### PR DESCRIPTION
## Summary
- `GET /api/v1/evidence` now returns a `total` field on first-page requests (no cursor)
- Backend runs `COUNT(*)` with the same filters before applying pagination; subsequent pages omit the field to avoid recounting
- Frontend caches the total across pagination and renders as either `N records` (single page) or `showing N of M records` (paginated)

## Test plan
- [x] `TestListEvidencePagination` — total is `5` on page 1, absent on pages 2 and 3
- [x] New `TestListEvidenceTotalWhenSinglePage` — total matches when results fit in one page
- [x] Full `go test ./...` passes
- [x] Live API test against 2M-row dataset: unfiltered returns `total: 2000576`; filtered `repo=…&branch=main` returns `total: 3`
- [x] Second page (with cursor) returns `total: null` as expected

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)