### PR TITLE
Add evidence-bazel record subcommand for shell-driven outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,57 @@ Or use the dogfood script that does both:
 | `--api-key` | `$EVIDENCE_STORE_API_KEY` | API key |
 | `--dry-run` | `false` | Print records instead of posting |
 
+### Recording ad-hoc results (`record` subcommand)
+
+Not all test workflows produce a JUnit `test.xml`. Failure tests (where a `bazel build` is *expected* to fail with a specific stderr pattern) and shell-driven integration tests determine pass/fail outside Bazel's test runner. For these, use the `record` subcommand to emit a single evidence record with an externally-determined verdict.
+
+```bash
+# Manual pass/fail decision
+evidence-bazel record \
+    --procedure-ref "//fire/starlark/failure_test:version_too_old_basic" \
+    --result PASS \
+    --notes "expected 'static_assert' pattern found in stderr" \
+    --tags failure_test,version_too_old \
+    --evidence-type bazel-failure-test
+```
+
+#### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--procedure-ref` | | Target label / test identifier (required) |
+| `--result` | | `PASS`, `FAIL`, `ERROR`, or `SKIPPED` (required, case-insensitive) |
+| `--evidence-type` | `bazel-manual` | Evidence type string |
+| `--notes` | | Free-text stored under `metadata.notes` |
+| `--tags` | | Comma-separated tags stored under `metadata.tags` |
+| `--duration-ms` | | Duration in milliseconds (optional) |
+| `--metadata` | | JSON object to merge into metadata (e.g. `'{"pattern":"static_assert"}'`) |
+| `--invocation-id` | | Group multiple records from the same run |
+| `--finished-at` | now (UTC) | RFC3339 timestamp |
+| `--repo`, `--branch`, `--rcs-ref`, `--source` | auto-detected | Same as ingest path |
+| `--api-url`, `--api-key` | env vars | Same as ingest path |
+| `--dry-run` | `false` | Print the record as JSON instead of posting |
+
+#### Example: driving failure tests from a shell script
+
+```bash
+INVOCATION_ID=$(uuidgen)
+for tgt in $(discover_failure_tests); do
+    if bazel build "$tgt" 2> stderr.log; then
+        evidence-bazel record --procedure-ref "$tgt" --result FAIL \
+            --notes "expected build failure but build succeeded" \
+            --invocation-id "$INVOCATION_ID"
+    elif grep -q "static_assert" stderr.log; then
+        evidence-bazel record --procedure-ref "$tgt" --result PASS \
+            --invocation-id "$INVOCATION_ID"
+    else
+        evidence-bazel record --procedure-ref "$tgt" --result ERROR \
+            --notes "build failed without expected pattern" \
+            --invocation-id "$INVOCATION_ID"
+    fi
+done
+```
+
 ### Watch Mode (Automatic Ingestion)
 
 The adapter can run as a background watcher that automatically uploads test results after every `bazel test` — no changes to your build workflow needed. The commands below assume a consumer workspace with `evidence_store_bazel` added as a `bazel_dep`; replace `@evidence_store_bazel//cmd/evidence-bazel` with `//cmd/evidence-bazel` when running from inside `adapters/bazel/` in this repo.

--- a/README.md
+++ b/README.md
@@ -131,14 +131,22 @@ Or use the dogfood script that does both:
 
 Not all test workflows produce a JUnit `test.xml`. Failure tests (where a `bazel build` is *expected* to fail with a specific stderr pattern) and shell-driven integration tests determine pass/fail outside Bazel's test runner. For these, use the `record` subcommand to emit a single evidence record with an externally-determined verdict.
 
+From a consumer workspace that has `evidence_store_bazel` as a `bazel_dep`:
+
 ```bash
-# Manual pass/fail decision
-evidence-bazel record \
+bazel run @evidence_store_bazel//cmd/evidence-bazel -- record \
     --procedure-ref "//fire/starlark/failure_test:version_too_old_basic" \
     --result PASS \
     --notes "expected 'static_assert' pattern found in stderr" \
     --tags failure_test,version_too_old \
     --evidence-type bazel-failure-test
+```
+
+For calls in tight loops (e.g., a shell script iterating dozens of targets), suppress Bazel's UI chatter so only the CLI's output comes through:
+
+```bash
+bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress \
+    @evidence_store_bazel//cmd/evidence-bazel -- record ...
 ```
 
 #### Flags

--- a/README.md
+++ b/README.md
@@ -139,14 +139,20 @@ bazel run @evidence_store_bazel//cmd/evidence-bazel -- record \
     --result PASS \
     --notes "expected 'static_assert' pattern found in stderr" \
     --tags failure_test,version_too_old \
-    --evidence-type bazel-failure-test
+    --evidence-type bazel_failure_test
 ```
 
-For calls in tight loops (e.g., a shell script iterating dozens of targets), suppress Bazel's UI chatter so only the CLI's output comes through:
+`--evidence-type` must match `^[a-z][a-z0-9_]{0,63}$` (lowercase, underscores, no hyphens).
+
+For calls in tight loops, avoid `bazel run` in the inner loop — its per-invocation configuration (and any differing `--action_env` flags on your other builds) churns the analysis cache. Build once up-front and exec the binary directly:
 
 ```bash
-bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress \
-    @evidence_store_bazel//cmd/evidence-bazel -- record ...
+bazel build @evidence_store_bazel//cmd/evidence-bazel
+BIN="$(bazel info workspace)/$(bazel cquery --output=files @evidence_store_bazel//cmd/evidence-bazel)"
+
+for tgt in $targets; do
+    "$BIN" record --procedure-ref "$tgt" --result PASS ...
+done
 ```
 
 #### Flags
@@ -163,10 +169,10 @@ bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress \
 | `--invocation-id` | | Group multiple records from the same run |
 | `--finished-at` | now (UTC) | RFC3339 timestamp |
 | `--repo`, `--branch`, `--rcs-ref`, `--source` | auto-detected | Same as ingest path |
-| `--api-url`, `--api-key` | `.evidence/config.yaml` → env vars | See below |
+| `--api-url`, `--api-key` | `.evidence/config.yaml` | See below |
 | `--dry-run` | `false` | Print the record as JSON instead of posting |
 
-Config resolution order (highest priority first): command-line flag → `EVIDENCE_STORE_URL` / `EVIDENCE_STORE_API_KEY` env vars → `.evidence/config.yaml` (searched upward from `BUILD_WORKSPACE_DIRECTORY` or cwd). This matches the watcher's behavior so the same config works for both.
+Config resolution order (highest priority first): command-line flag → `.evidence/config.yaml` (searched upward from `BUILD_WORKSPACE_DIRECTORY` or cwd). Environment variables are deliberately not consulted by `record`, so the binary's behavior is stable across shell-env changes and Bazel's analysis cache is not invalidated by invocations that happen to have different env.
 
 #### Example: driving failure tests from a shell script
 

--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ evidence-bazel record \
 | `--invocation-id` | | Group multiple records from the same run |
 | `--finished-at` | now (UTC) | RFC3339 timestamp |
 | `--repo`, `--branch`, `--rcs-ref`, `--source` | auto-detected | Same as ingest path |
-| `--api-url`, `--api-key` | env vars | Same as ingest path |
+| `--api-url`, `--api-key` | `.evidence/config.yaml` → env vars | See below |
 | `--dry-run` | `false` | Print the record as JSON instead of posting |
+
+Config resolution order (highest priority first): command-line flag → `EVIDENCE_STORE_URL` / `EVIDENCE_STORE_API_KEY` env vars → `.evidence/config.yaml` (searched upward from `BUILD_WORKSPACE_DIRECTORY` or cwd). This matches the watcher's behavior so the same config works for both.
 
 #### Example: driving failure tests from a shell script
 

--- a/adapters/bazel/cmd/evidence-bazel/BUILD.bazel
+++ b/adapters/bazel/cmd/evidence-bazel/BUILD.bazel
@@ -1,8 +1,11 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "evidence-bazel_lib",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "record.go",
+    ],
     importpath = "github.com/nesono/evidence-store/adapters/bazel/cmd/evidence-bazel",
     visibility = ["//visibility:private"],
     deps = [
@@ -18,4 +21,15 @@ go_binary(
     name = "evidence-bazel",
     embed = [":evidence-bazel_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "evidence-bazel_test",
+    srcs = ["record_test.go"],
+    embed = [":evidence-bazel_lib"],
+    deps = [
+        "//internal/client",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/adapters/bazel/cmd/evidence-bazel/main.go
+++ b/adapters/bazel/cmd/evidence-bazel/main.go
@@ -19,10 +19,16 @@ import (
 )
 
 func main() {
-	// Handle "watch" subcommand before flag parsing.
-	if len(os.Args) > 1 && os.Args[1] == "watch" {
-		runWatch(os.Args[2:])
-		return
+	// Handle subcommands before flag parsing.
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "watch":
+			runWatch(os.Args[2:])
+			return
+		case "record":
+			runRecord(os.Args[2:])
+			return
+		}
 	}
 
 	var (

--- a/adapters/bazel/cmd/evidence-bazel/record.go
+++ b/adapters/bazel/cmd/evidence-bazel/record.go
@@ -8,12 +8,39 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/nesono/evidence-store/adapters/bazel/internal/client"
 	"github.com/nesono/evidence-store/adapters/bazel/internal/gitinfo"
+	"github.com/nesono/evidence-store/adapters/bazel/internal/watch"
 )
+
+// findWorkspaceDir returns the directory containing .evidence/config.yaml,
+// searching upward from BUILD_WORKSPACE_DIRECTORY (when set) or cwd. Returns
+// empty string when no config file is found.
+func findWorkspaceDir() string {
+	start := os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	if start == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return ""
+		}
+		start = cwd
+	}
+	dir := start
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".evidence", "config.yaml")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
 
 type recordOptions struct {
 	APIURL       string
@@ -123,10 +150,30 @@ func writeRecord(w io.Writer, rec client.EvidenceRecord) error {
 }
 
 func runRecord(args []string) {
+	// Resolve config defaults: .evidence/config.yaml (if present) → env vars.
+	// Command-line flags override both via flag.Parse.
+	var cfgAPIURL, cfgAPIKey, cfgTags string
+	if wd := findWorkspaceDir(); wd != "" {
+		cfg, err := watch.LoadConfig(wd)
+		if err != nil {
+			slog.Warn("failed to load .evidence/config.yaml", "dir", wd, "error", err)
+		} else {
+			cfgAPIURL = cfg.APIURL
+			cfgAPIKey = cfg.APIKey
+			if len(cfg.Tags) > 0 {
+				cfgTags = strings.Join(cfg.Tags, ",")
+			}
+		}
+	} else {
+		// No config file; fall back to env vars directly.
+		cfgAPIURL = os.Getenv("EVIDENCE_STORE_URL")
+		cfgAPIKey = os.Getenv("EVIDENCE_STORE_API_KEY")
+	}
+
 	fs := flag.NewFlagSet("record", flag.ExitOnError)
 
-	apiURL := fs.String("api-url", envOrDefault("EVIDENCE_STORE_URL", ""), "Evidence Store API base URL (required unless --dry-run)")
-	apiKey := fs.String("api-key", envOrDefault("EVIDENCE_STORE_API_KEY", ""), "API key for authentication (optional)")
+	apiURL := fs.String("api-url", cfgAPIURL, "Evidence Store API base URL (required unless --dry-run)")
+	apiKey := fs.String("api-key", cfgAPIKey, "API key for authentication (optional)")
 	repo := fs.String("repo", "", "Repository identifier (auto-detected from git remote)")
 	branch := fs.String("branch", "", "Branch name (auto-detected from git)")
 	rcsRef := fs.String("rcs-ref", "", "RCS reference / commit hash (auto-detected from git HEAD)")
@@ -135,7 +182,7 @@ func runRecord(args []string) {
 	evidenceType := fs.String("evidence-type", "bazel-manual", "Evidence type (e.g. bazel-failure-test)")
 	result := fs.String("result", "", "Result: PASS, FAIL, ERROR, or SKIPPED (required)")
 	notes := fs.String("notes", "", "Free-text context stored under metadata.notes")
-	tags := fs.String("tags", "", "Comma-separated tags stored under metadata.tags")
+	tags := fs.String("tags", cfgTags, "Comma-separated tags stored under metadata.tags")
 	durationMS := fs.Int64("duration-ms", 0, "Duration in milliseconds (optional)")
 	metadataJSON := fs.String("metadata", "", "JSON object of arbitrary metadata to merge")
 	invocationID := fs.String("invocation-id", "", "Bazel invocation ID (optional)")

--- a/adapters/bazel/cmd/evidence-bazel/record.go
+++ b/adapters/bazel/cmd/evidence-bazel/record.go
@@ -108,7 +108,7 @@ func buildRecord(opts recordOptions) (client.EvidenceRecord, error) {
 
 	evidenceType := opts.EvidenceType
 	if evidenceType == "" {
-		evidenceType = "bazel-manual"
+		evidenceType = "bazel_manual"
 	}
 
 	rec := client.EvidenceRecord{
@@ -150,11 +150,12 @@ func writeRecord(w io.Writer, rec client.EvidenceRecord) error {
 }
 
 func runRecord(args []string) {
-	// Resolve config defaults: .evidence/config.yaml (if present) → env vars.
-	// Command-line flags override both via flag.Parse.
+	// Resolve config defaults from .evidence/config.yaml only. Environment
+	// variables are deliberately ignored so that Bazel invocations remain
+	// analysis-cache-stable regardless of shell environment.
 	var cfgAPIURL, cfgAPIKey, cfgTags string
 	if wd := findWorkspaceDir(); wd != "" {
-		cfg, err := watch.LoadConfig(wd)
+		cfg, err := watch.LoadConfigFile(wd)
 		if err != nil {
 			slog.Warn("failed to load .evidence/config.yaml", "dir", wd, "error", err)
 		} else {
@@ -164,10 +165,6 @@ func runRecord(args []string) {
 				cfgTags = strings.Join(cfg.Tags, ",")
 			}
 		}
-	} else {
-		// No config file; fall back to env vars directly.
-		cfgAPIURL = os.Getenv("EVIDENCE_STORE_URL")
-		cfgAPIKey = os.Getenv("EVIDENCE_STORE_API_KEY")
 	}
 
 	fs := flag.NewFlagSet("record", flag.ExitOnError)
@@ -179,7 +176,7 @@ func runRecord(args []string) {
 	rcsRef := fs.String("rcs-ref", "", "RCS reference / commit hash (auto-detected from git HEAD)")
 	source := fs.String("source", "", "Source identifier: CI build URL or username (auto-detected)")
 	procedureRef := fs.String("procedure-ref", "", "Procedure / test identifier (required)")
-	evidenceType := fs.String("evidence-type", "bazel-manual", "Evidence type (e.g. bazel-failure-test)")
+	evidenceType := fs.String("evidence-type", "bazel_manual", "Evidence type (e.g. bazel_failure_test). Must match ^[a-z][a-z0-9_]{0,63}$.")
 	result := fs.String("result", "", "Result: PASS, FAIL, ERROR, or SKIPPED (required)")
 	notes := fs.String("notes", "", "Free-text context stored under metadata.notes")
 	tags := fs.String("tags", cfgTags, "Comma-separated tags stored under metadata.tags")

--- a/adapters/bazel/cmd/evidence-bazel/record.go
+++ b/adapters/bazel/cmd/evidence-bazel/record.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nesono/evidence-store/adapters/bazel/internal/client"
+	"github.com/nesono/evidence-store/adapters/bazel/internal/gitinfo"
+)
+
+type recordOptions struct {
+	APIURL       string
+	APIKey       string
+	Repo         string
+	Branch       string
+	RCSRef       string
+	Source       string
+	ProcedureRef string
+	EvidenceType string
+	Result       string
+	Notes        string
+	Tags         string
+	DurationMS   int64
+	Metadata     string
+	InvocationID string
+	FinishedAt   string
+	DryRun       bool
+}
+
+// buildRecord validates options and constructs a single EvidenceRecord.
+// The caller is responsible for populating Repo/Branch/RCSRef (typically via
+// gitinfo.Detect).
+func buildRecord(opts recordOptions) (client.EvidenceRecord, error) {
+	if opts.ProcedureRef == "" {
+		return client.EvidenceRecord{}, fmt.Errorf("--procedure-ref is required")
+	}
+	if opts.Repo == "" {
+		return client.EvidenceRecord{}, fmt.Errorf("--repo is required (could not auto-detect)")
+	}
+	if opts.RCSRef == "" {
+		return client.EvidenceRecord{}, fmt.Errorf("--rcs-ref is required (could not auto-detect)")
+	}
+
+	result := strings.ToUpper(strings.TrimSpace(opts.Result))
+	switch result {
+	case "PASS", "FAIL", "ERROR", "SKIPPED":
+	default:
+		return client.EvidenceRecord{}, fmt.Errorf("--result must be one of PASS, FAIL, ERROR, SKIPPED (got %q)", opts.Result)
+	}
+
+	finishedAt := opts.FinishedAt
+	if finishedAt == "" {
+		finishedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	metadata := map[string]any{}
+	if opts.Metadata != "" {
+		if err := json.Unmarshal([]byte(opts.Metadata), &metadata); err != nil {
+			return client.EvidenceRecord{}, fmt.Errorf("--metadata must be a JSON object: %w", err)
+		}
+	}
+	if opts.Notes != "" {
+		metadata["notes"] = opts.Notes
+	}
+	if tags := parseTags(opts.Tags); len(tags) > 0 {
+		metadata["tags"] = tags
+	}
+	if opts.DurationMS > 0 {
+		metadata["duration_ms"] = opts.DurationMS
+	}
+	if opts.InvocationID != "" {
+		metadata["invocation_id"] = opts.InvocationID
+	}
+
+	evidenceType := opts.EvidenceType
+	if evidenceType == "" {
+		evidenceType = "bazel-manual"
+	}
+
+	rec := client.EvidenceRecord{
+		Repo:         opts.Repo,
+		Branch:       opts.Branch,
+		RCSRef:       opts.RCSRef,
+		ProcedureRef: opts.ProcedureRef,
+		EvidenceType: evidenceType,
+		Source:       opts.Source,
+		Result:       result,
+		FinishedAt:   finishedAt,
+	}
+	if len(metadata) > 0 {
+		rec.Metadata = metadata
+	}
+	return rec, nil
+}
+
+func parseTags(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, t := range strings.Split(s, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func writeRecord(w io.Writer, rec client.EvidenceRecord) error {
+	b, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(b))
+	return err
+}
+
+func runRecord(args []string) {
+	fs := flag.NewFlagSet("record", flag.ExitOnError)
+
+	apiURL := fs.String("api-url", envOrDefault("EVIDENCE_STORE_URL", ""), "Evidence Store API base URL (required unless --dry-run)")
+	apiKey := fs.String("api-key", envOrDefault("EVIDENCE_STORE_API_KEY", ""), "API key for authentication (optional)")
+	repo := fs.String("repo", "", "Repository identifier (auto-detected from git remote)")
+	branch := fs.String("branch", "", "Branch name (auto-detected from git)")
+	rcsRef := fs.String("rcs-ref", "", "RCS reference / commit hash (auto-detected from git HEAD)")
+	source := fs.String("source", "", "Source identifier: CI build URL or username (auto-detected)")
+	procedureRef := fs.String("procedure-ref", "", "Procedure / test identifier (required)")
+	evidenceType := fs.String("evidence-type", "bazel-manual", "Evidence type (e.g. bazel-failure-test)")
+	result := fs.String("result", "", "Result: PASS, FAIL, ERROR, or SKIPPED (required)")
+	notes := fs.String("notes", "", "Free-text context stored under metadata.notes")
+	tags := fs.String("tags", "", "Comma-separated tags stored under metadata.tags")
+	durationMS := fs.Int64("duration-ms", 0, "Duration in milliseconds (optional)")
+	metadataJSON := fs.String("metadata", "", "JSON object of arbitrary metadata to merge")
+	invocationID := fs.String("invocation-id", "", "Bazel invocation ID (optional)")
+	finishedAt := fs.String("finished-at", "", "Finish time (RFC3339). Defaults to now (UTC)")
+	dryRun := fs.Bool("dry-run", false, "Print record to stdout instead of posting")
+
+	_ = fs.Parse(args)
+
+	if *repo == "" || *branch == "" || *rcsRef == "" {
+		info, err := gitinfo.Detect()
+		if err != nil {
+			slog.Warn("could not auto-detect git info", "error", err)
+		} else {
+			if *repo == "" {
+				*repo = info.Repo
+			}
+			if *branch == "" {
+				*branch = info.Branch
+			}
+			if *rcsRef == "" {
+				*rcsRef = info.Ref
+			}
+		}
+	}
+	if *source == "" {
+		*source = gitinfo.DetectSource()
+	}
+
+	opts := recordOptions{
+		APIURL:       *apiURL,
+		APIKey:       *apiKey,
+		Repo:         *repo,
+		Branch:       *branch,
+		RCSRef:       *rcsRef,
+		Source:       *source,
+		ProcedureRef: *procedureRef,
+		EvidenceType: *evidenceType,
+		Result:       *result,
+		Notes:        *notes,
+		Tags:         *tags,
+		DurationMS:   *durationMS,
+		Metadata:     *metadataJSON,
+		InvocationID: *invocationID,
+		FinishedAt:   *finishedAt,
+		DryRun:       *dryRun,
+	}
+
+	rec, err := buildRecord(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if opts.DryRun {
+		if err := writeRecord(os.Stdout, rec); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if opts.APIURL == "" {
+		fmt.Fprintln(os.Stderr, "error: --api-url is required (or set EVIDENCE_STORE_URL)")
+		os.Exit(1)
+	}
+
+	var clientOpts []client.Option
+	if opts.APIKey != "" {
+		clientOpts = append(clientOpts, client.WithAPIKey(opts.APIKey))
+	}
+	c := client.New(opts.APIURL, clientOpts...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	responses, err := c.PostBatch(ctx, []client.EvidenceRecord{rec})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error posting evidence: %v\n", err)
+		os.Exit(1)
+	}
+	for _, resp := range responses {
+		for _, r := range resp.Results {
+			if r.Status != "created" {
+				fmt.Fprintf(os.Stderr, "record failed: %s\n", r.Error)
+				os.Exit(1)
+			}
+		}
+	}
+	slog.Info("record posted", "procedure_ref", rec.ProcedureRef, "result", rec.Result)
+}

--- a/adapters/bazel/cmd/evidence-bazel/record_test.go
+++ b/adapters/bazel/cmd/evidence-bazel/record_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nesono/evidence-store/adapters/bazel/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validRecordOptions() recordOptions {
+	return recordOptions{
+		Repo:         "nesono/evidence_store",
+		Branch:       "main",
+		RCSRef:       "abc123",
+		ProcedureRef: "//pkg:failure_test",
+		Result:       "PASS",
+	}
+}
+
+func TestBuildRecord_Minimal(t *testing.T) {
+	rec, err := buildRecord(validRecordOptions())
+	require.NoError(t, err)
+
+	assert.Equal(t, "nesono/evidence_store", rec.Repo)
+	assert.Equal(t, "PASS", rec.Result)
+	assert.Equal(t, "bazel-manual", rec.EvidenceType)
+	assert.Equal(t, "//pkg:failure_test", rec.ProcedureRef)
+	assert.Nil(t, rec.Metadata)
+
+	_, err = time.Parse(time.RFC3339, rec.FinishedAt)
+	assert.NoError(t, err, "FinishedAt should default to RFC3339 now")
+}
+
+func TestBuildRecord_NormalizesResultCase(t *testing.T) {
+	opts := validRecordOptions()
+	opts.Result = "  fail  "
+	rec, err := buildRecord(opts)
+	require.NoError(t, err)
+	assert.Equal(t, "FAIL", rec.Result)
+}
+
+func TestBuildRecord_InvalidResult(t *testing.T) {
+	opts := validRecordOptions()
+	opts.Result = "MAYBE"
+	_, err := buildRecord(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be one of PASS, FAIL, ERROR, SKIPPED")
+}
+
+func TestBuildRecord_RequiredFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*recordOptions)
+		wantMsg string
+	}{
+		{"missing procedure-ref", func(o *recordOptions) { o.ProcedureRef = "" }, "--procedure-ref is required"},
+		{"missing repo", func(o *recordOptions) { o.Repo = "" }, "--repo is required"},
+		{"missing rcs-ref", func(o *recordOptions) { o.RCSRef = "" }, "--rcs-ref is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := validRecordOptions()
+			tc.mutate(&opts)
+			_, err := buildRecord(opts)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
+func TestBuildRecord_MergesMetadata(t *testing.T) {
+	opts := validRecordOptions()
+	opts.Notes = "expected static_assert pattern found"
+	opts.Tags = "failure_test, version_too_old ,"
+	opts.DurationMS = 150
+	opts.InvocationID = "inv-uuid"
+	opts.Metadata = `{"weather":"sunny","trial":3}`
+
+	rec, err := buildRecord(opts)
+	require.NoError(t, err)
+
+	md := rec.Metadata
+	require.NotNil(t, md)
+	assert.Equal(t, "expected static_assert pattern found", md["notes"])
+	assert.Equal(t, []string{"failure_test", "version_too_old"}, md["tags"])
+	assert.Equal(t, int64(150), md["duration_ms"])
+	assert.Equal(t, "inv-uuid", md["invocation_id"])
+	assert.Equal(t, "sunny", md["weather"])
+	assert.EqualValues(t, 3, md["trial"])
+}
+
+func TestBuildRecord_MetadataFlagsOverrideRawMetadata(t *testing.T) {
+	// If user supplies metadata JSON that includes "notes", the explicit
+	// --notes flag should win.
+	opts := validRecordOptions()
+	opts.Metadata = `{"notes":"from-json","other":"keep"}`
+	opts.Notes = "from-flag"
+
+	rec, err := buildRecord(opts)
+	require.NoError(t, err)
+
+	md := rec.Metadata
+	require.NotNil(t, md)
+	assert.Equal(t, "from-flag", md["notes"])
+	assert.Equal(t, "keep", md["other"])
+}
+
+func TestBuildRecord_InvalidMetadataJSON(t *testing.T) {
+	opts := validRecordOptions()
+	opts.Metadata = "not json"
+	_, err := buildRecord(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a JSON object")
+}
+
+func TestBuildRecord_FinishedAtPassthrough(t *testing.T) {
+	opts := validRecordOptions()
+	opts.FinishedAt = "2026-04-18T10:00:00Z"
+	rec, err := buildRecord(opts)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-04-18T10:00:00Z", rec.FinishedAt)
+}
+
+func TestBuildRecord_CustomEvidenceType(t *testing.T) {
+	opts := validRecordOptions()
+	opts.EvidenceType = "bazel-failure-test"
+	rec, err := buildRecord(opts)
+	require.NoError(t, err)
+	assert.Equal(t, "bazel-failure-test", rec.EvidenceType)
+}
+
+func TestBuildRecord_EmptyTagsDoesNotAddKey(t *testing.T) {
+	opts := validRecordOptions()
+	opts.Tags = " , , "
+	rec, err := buildRecord(opts)
+	require.NoError(t, err)
+	assert.Nil(t, rec.Metadata, "metadata should remain nil when tag string yields no tags")
+}
+
+func TestBuildRecord_ZeroDurationNotStored(t *testing.T) {
+	opts := validRecordOptions()
+	opts.DurationMS = 0
+	rec, err := buildRecord(opts)
+	require.NoError(t, err)
+	assert.Nil(t, rec.Metadata)
+}
+
+func TestWriteRecord_ProducesParseableJSON(t *testing.T) {
+	rec := client.EvidenceRecord{
+		Repo:         "nesono/evidence_store",
+		Branch:       "main",
+		RCSRef:       "abc123",
+		ProcedureRef: "//pkg:ft",
+		EvidenceType: "bazel-failure-test",
+		Result:       "PASS",
+		FinishedAt:   "2026-04-18T10:00:00Z",
+		Metadata:     map[string]any{"notes": "ok"},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, writeRecord(&buf, rec))
+
+	var back client.EvidenceRecord
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &back))
+	assert.Equal(t, rec.ProcedureRef, back.ProcedureRef)
+	assert.Equal(t, rec.Result, back.Result)
+}

--- a/adapters/bazel/cmd/evidence-bazel/record_test.go
+++ b/adapters/bazel/cmd/evidence-bazel/record_test.go
@@ -29,7 +29,7 @@ func TestBuildRecord_Minimal(t *testing.T) {
 
 	assert.Equal(t, "nesono/evidence_store", rec.Repo)
 	assert.Equal(t, "PASS", rec.Result)
-	assert.Equal(t, "bazel-manual", rec.EvidenceType)
+	assert.Equal(t, "bazel_manual", rec.EvidenceType)
 	assert.Equal(t, "//pkg:failure_test", rec.ProcedureRef)
 	assert.Nil(t, rec.Metadata)
 
@@ -129,10 +129,10 @@ func TestBuildRecord_FinishedAtPassthrough(t *testing.T) {
 
 func TestBuildRecord_CustomEvidenceType(t *testing.T) {
 	opts := validRecordOptions()
-	opts.EvidenceType = "bazel-failure-test"
+	opts.EvidenceType = "bazel_failure_test"
 	rec, err := buildRecord(opts)
 	require.NoError(t, err)
-	assert.Equal(t, "bazel-failure-test", rec.EvidenceType)
+	assert.Equal(t, "bazel_failure_test", rec.EvidenceType)
 }
 
 func TestBuildRecord_EmptyTagsDoesNotAddKey(t *testing.T) {

--- a/adapters/bazel/cmd/evidence-bazel/record_test.go
+++ b/adapters/bazel/cmd/evidence-bazel/record_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -147,6 +149,42 @@ func TestBuildRecord_ZeroDurationNotStored(t *testing.T) {
 	rec, err := buildRecord(opts)
 	require.NoError(t, err)
 	assert.Nil(t, rec.Metadata)
+}
+
+func TestFindWorkspaceDir_LocatesConfigFile(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, ".evidence")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("api_url: http://x\n"), 0o644))
+
+	// BUILD_WORKSPACE_DIRECTORY takes precedence.
+	t.Setenv("BUILD_WORKSPACE_DIRECTORY", root)
+	got := findWorkspaceDir()
+	// Resolve symlinks for macOS /var → /private/var.
+	gotAbs, _ := filepath.EvalSymlinks(got)
+	rootAbs, _ := filepath.EvalSymlinks(root)
+	assert.Equal(t, rootAbs, gotAbs)
+}
+
+func TestFindWorkspaceDir_WalksUpward(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".evidence"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".evidence", "config.yaml"), []byte(""), 0o644))
+
+	nested := filepath.Join(root, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	t.Setenv("BUILD_WORKSPACE_DIRECTORY", nested)
+
+	got := findWorkspaceDir()
+	gotAbs, _ := filepath.EvalSymlinks(got)
+	rootAbs, _ := filepath.EvalSymlinks(root)
+	assert.Equal(t, rootAbs, gotAbs)
+}
+
+func TestFindWorkspaceDir_ReturnsEmptyWhenNotFound(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("BUILD_WORKSPACE_DIRECTORY", root)
+	assert.Equal(t, "", findWorkspaceDir())
 }
 
 func TestWriteRecord_ProducesParseableJSON(t *testing.T) {

--- a/adapters/bazel/internal/watch/config.go
+++ b/adapters/bazel/internal/watch/config.go
@@ -26,9 +26,10 @@ func DefaultConfig() Config {
 	}
 }
 
-// LoadConfig loads config from .evidence/config.yaml in the given workspace
-// directory, then overlays environment variables. Missing file is not an error.
-func LoadConfig(workspaceDir string) (Config, error) {
+// LoadConfigFile loads config from .evidence/config.yaml in the given
+// workspace directory. It does NOT consult environment variables, so the
+// YAML is the single source of truth. Missing file is not an error.
+func LoadConfigFile(workspaceDir string) (Config, error) {
 	cfg := DefaultConfig()
 
 	configPath := filepath.Join(workspaceDir, ".evidence", "config.yaml")
@@ -41,15 +42,6 @@ func LoadConfig(workspaceDir string) (Config, error) {
 		return cfg, fmt.Errorf("read %s: %w", configPath, err)
 	}
 
-	// Environment variables override file config.
-	if v := os.Getenv("EVIDENCE_STORE_URL"); v != "" {
-		cfg.APIURL = v
-	}
-	if v := os.Getenv("EVIDENCE_STORE_API_KEY"); v != "" {
-		cfg.APIKey = v
-	}
-
-	// Ensure defaults for durations if zero (e.g. from partial YAML).
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = 5 * time.Second
 	}
@@ -57,6 +49,23 @@ func LoadConfig(workspaceDir string) (Config, error) {
 		cfg.DebounceWait = 2 * time.Second
 	}
 
+	return cfg, nil
+}
+
+// LoadConfig loads config from .evidence/config.yaml, then overlays
+// EVIDENCE_STORE_URL and EVIDENCE_STORE_API_KEY env vars. Used by the
+// watch subcommand for backwards compatibility with pre-file deployments.
+func LoadConfig(workspaceDir string) (Config, error) {
+	cfg, err := LoadConfigFile(workspaceDir)
+	if err != nil {
+		return cfg, err
+	}
+	if v := os.Getenv("EVIDENCE_STORE_URL"); v != "" {
+		cfg.APIURL = v
+	}
+	if v := os.Getenv("EVIDENCE_STORE_API_KEY"); v != "" {
+		cfg.APIKey = v
+	}
 	return cfg, nil
 }
 


### PR DESCRIPTION
## Summary

- New `record` subcommand in `evidence-bazel` that emits a single evidence record with an externally-determined verdict.
- Enables capturing results for workflows that don't produce a JUnit `test.xml` — notably **failure tests** (`bazel build` expected to fail with a specific stderr pattern) and shell-driven integration tests (e.g., `bazel build ... && grep -q "Handbook Entry" report.md`).
- Reuses existing git auto-detection (`gitinfo.Detect`) and HTTP client; no backend changes.

## Flags

Required: `--procedure-ref`, `--result` (PASS/FAIL/ERROR/SKIPPED, case-insensitive).
Optional: `--notes`, `--tags`, `--duration-ms`, `--metadata` (JSON object merged into metadata), `--invocation-id`, `--finished-at`, `--evidence-type` (default `bazel-manual`). Inherits `--api-url`, `--api-key`, `--repo`, `--branch`, `--rcs-ref`, `--source`, `--dry-run` from the ingest path.

Explicit `--notes` wins over a `notes` key inside `--metadata` (flags are the higher-priority input).

## Example

```bash
INVOCATION_ID=$(uuidgen)
for tgt in $(discover_failure_tests); do
    if bazel build "$tgt" 2> stderr.log; then
        evidence-bazel record --procedure-ref "$tgt" --result FAIL \
            --notes "expected build failure but build succeeded" \
            --invocation-id "$INVOCATION_ID"
    elif grep -q "static_assert" stderr.log; then
        evidence-bazel record --procedure-ref "$tgt" --result PASS \
            --invocation-id "$INVOCATION_ID"
    else
        evidence-bazel record --procedure-ref "$tgt" --result ERROR \
            --notes "build failed without expected pattern" \
            --invocation-id "$INVOCATION_ID"
    fi
done
```

Closes #46.

## Test plan

- [x] `bazel test //...` in `adapters/bazel/` — 6/6 pass
- [x] Smoke test: `--dry-run` produces correct JSON with auto-detected git info, merged metadata, uppercased result, default `finished_at`
- [x] Post a record against a local server and verify it appears via `GET /api/v1/evidence`

🤖 Generated with [Claude Code](https://claude.com/claude-code)