### PR TITLE
Add Bazel Central Registry publishing scaffolding

### DIFF
--- a/.bcr/adapters/bazel/metadata.template.json
+++ b/.bcr/adapters/bazel/metadata.template.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/nesono/evidence_store",
+    "maintainers": [
+        {
+            "email": "github@nesono.com",
+            "github": "nesono",
+            "name": "nesono"
+        }
+    ],
+    "repository": [
+        "github:nesono/evidence_store"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/adapters/bazel/presubmit.yml
+++ b/.bcr/adapters/bazel/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - macos
+  bazel: [7.*, 8.*, 9.*]
+
+tasks:
+  verify_build:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "//cmd/evidence-bazel"
+  verify_tests:
+    name: Run adapter tests
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "//..."

--- a/.bcr/adapters/bazel/source.template.json
+++ b/.bcr/adapters/bazel/source.template.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "**leave this alone**",
+    "strip_prefix": "evidence_store_bazel-v{VERSION}",
+    "url": "https://github.com/nesono/evidence_store/releases/download/evidence_store_bazel-v{VERSION}/evidence_store_bazel-v{VERSION}.tar.gz"
+}

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,6 @@
+moduleRoots:
+  - adapters/bazel
+
+fixedReleaser:
+  login: nesono
+  email: github@nesono.com

--- a/.github/workflows/release-bazel-adapter.yml
+++ b/.github/workflows/release-bazel-adapter.yml
@@ -1,0 +1,68 @@
+name: Release evidence_store_bazel
+
+on:
+  push:
+    tags:
+      - "evidence_store_bazel-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.vars.outputs.tag }}
+      version: ${{ steps.vars.outputs.version }}
+      prefix: ${{ steps.vars.outputs.prefix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute version vars
+        id: vars
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#evidence_store_bazel-v}"
+          PREFIX="evidence_store_bazel-v${VERSION}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "prefix=${PREFIX}" >> "$GITHUB_OUTPUT"
+
+      - name: Build source tarball
+        run: |
+          set -euo pipefail
+          PREFIX="${{ steps.vars.outputs.prefix }}"
+          mkdir -p "staging/${PREFIX}"
+          rsync -a \
+            --exclude 'bazel-*' \
+            adapters/bazel/ "staging/${PREFIX}/"
+          tar -C staging \
+            --sort=name \
+            --owner=0 --group=0 --numeric-owner \
+            -czf "${PREFIX}.tar.gz" "${PREFIX}"
+          sha256sum "${PREFIX}.tar.gz"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.vars.outputs.tag }}
+          name: evidence_store_bazel ${{ steps.vars.outputs.version }}
+          files: ${{ steps.vars.outputs.prefix }}.tar.gz
+          generate_release_notes: true
+
+  publish:
+    needs: release
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@main
+    with:
+      tag_name: ${{ needs.release.outputs.tag }}
+      tag_prefix: evidence_store_bazel-v
+      registry_fork: nesono/bazel-central-registry
+      attest: false
+      download_default_release_artifacts: false
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -220,6 +220,23 @@ The watcher polls `bazel-testlogs/` every 5 seconds, waits for Bazel to finish (
 
 Use `--foreground` with `watch start` to run in the foreground (useful for debugging).
 
+### Releasing to the Bazel Central Registry
+
+The adapter module (`evidence_store_bazel`) is published to the [Bazel Central Registry](https://registry.bazel.build/) so consumers can pin it via `bazel_dep` without a `git_override`.
+
+**Release flow:**
+
+1. Bump `version` in `adapters/bazel/MODULE.bazel`.
+2. Commit and merge to `main`.
+3. Tag the commit with `evidence_store_bazel-v<version>` (e.g., `evidence_store_bazel-v0.0.1`) and push the tag.
+4. The `Release evidence_store_bazel` workflow (`.github/workflows/release-bazel-adapter.yml`) builds a source tarball of `adapters/bazel/`, creates a GitHub release, then calls the [`bazel-contrib/publish-to-bcr`](https://github.com/bazel-contrib/publish-to-bcr) reusable workflow to open a PR against [`bazelbuild/bazel-central-registry`](https://github.com/bazelbuild/bazel-central-registry) from the fork configured in the workflow.
+
+**One-time setup (before the first release):**
+
+- Fork `bazelbuild/bazel-central-registry` to `nesono/bazel-central-registry`.
+- Create a classic Personal Access Token with `public_repo` scope and save it as the `BCR_PUBLISH_TOKEN` repository secret.
+- BCR templates live in `.bcr/` at the repo root; `.bcr/config.yml` declares `adapters/bazel` as the module root.
+
 ## API
 
 Base URL: `/api/v1`

--- a/adapters/bazel/LICENSE
+++ b/adapters/bazel/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 nesono
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/adapters/bazel/MODULE.bazel
+++ b/adapters/bazel/MODULE.bazel
@@ -1,6 +1,7 @@
 module(
     name = "evidence_store_bazel",
     version = "0.0.1",
+    compatibility_level = 1,
 )
 
 bazel_dep(name = "rules_go", version = "0.60.0")


### PR DESCRIPTION
## Summary
- Adds `.bcr/` templates (`metadata.template.json`, `source.template.json`, `presubmit.yml`) under `moduleRoots: [adapters/bazel]` per the multi-module publish-to-bcr convention, plus `fixedReleaser` config for `nesono / github@nesono.com`.
- Adds `.github/workflows/release-bazel-adapter.yml`: on `evidence_store_bazel-v*` tag push, builds a reproducible source tarball of `adapters/bazel/`, creates a GitHub release, then calls the `bazel-contrib/publish-to-bcr` reusable workflow to open a PR against the registry fork.
- Adds `adapters/bazel/LICENSE` (MIT, same as root), `compatibility_level = 1` in `adapters/bazel/MODULE.bazel`, and a "Releasing to the Bazel Central Registry" section in the README.

## Before the first release
- Fork `bazelbuild/bazel-central-registry` to `nesono/bazel-central-registry`.
- Create a classic PAT with `public_repo` scope and add it as the `BCR_PUBLISH_TOKEN` repo secret (fine-grained PATs cannot open PRs against public repos yet).

## Release flow
1. Bump `version` in `adapters/bazel/MODULE.bazel` and merge to `main`.
2. Tag the commit `evidence_store_bazel-v<version>` and push — the workflow builds the tarball, creates the release, and opens the BCR PR.

## Test plan
- [x] `bazel build //cmd/evidence-bazel` still succeeds inside `adapters/bazel/` (sanity-checked locally).
- [ ] After merge + first tag, verify GitHub release is created with `evidence_store_bazel-v<ver>.tar.gz` attached.
- [ ] Verify the publish-to-bcr job opens a draft PR against `nesono/bazel-central-registry`.
- [ ] Smoke-test the draft BCR PR locally (`bazel build @evidence_store_bazel//cmd/evidence-bazel`) before promoting to the public registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)