### PR TITLE
Block routine postgres major upgrades in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,13 @@
     {
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Postgres: minor/patch/digest updates are fine. Block routine major upgrades (data migration is costly); a vulnerability alert can still drive one if needed via vulnerabilityAlerts.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["postgres"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary
- Adds one `packageRule` for the postgres docker image: `enabled: false` only for `matchUpdateTypes: ["major"]`.
- Minor/patch/digest updates within the current major still flow normally.
- A CVE-driven major can still land via `vulnerabilityAlerts`, which overrides `enabled: false`.
- Closes the loop on the noisy "update postgres docker tag to v18" PR (#41).

## Behavior after merge
- PR #41 will go stale; close it manually.
- Future postgres minor/patch/digest changes still produce PRs.
- Routine `16-alpine` → `17-alpine` / `18-alpine` major bumps will not.

## Test plan
- [ ] Close PR #41 after merging this.
- [ ] Confirm next renovate run doesn't reopen a postgres major-bump PR.
- [ ] When ready for postgres 17/18, remove the rule (or do a manual bump) alongside the migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)