### PR TITLE
Add UTC preview hint under datetime fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bazel-*
 /adapters/bazel/bazel-*
 .evidence/
+/.claude/

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -336,6 +336,7 @@ document.getElementById("filter-form").addEventListener("submit", (e) => {
 document.getElementById("clear-filters").addEventListener("click", () => {
   const form = document.getElementById("filter-form");
   form.reset();
+  form.querySelectorAll("input[data-utc-preview]").forEach(updateUtcPreview);
   cursorStack = [];
   writeFiltersToURL({});
   document.getElementById("results-body").innerHTML =
@@ -513,8 +514,36 @@ function readCustomFields() {
 }
 
 document.getElementById("fill-now").addEventListener("click", () => {
-  document.querySelector('#add-form [name="finished_at"]').value = formatTime(new Date().toISOString());
+  const input = document.querySelector('#add-form [name="finished_at"]');
+  input.value = formatTime(new Date().toISOString());
+  updateUtcPreview(input);
 });
+
+function updateUtcPreview(input) {
+  const preview = document.querySelector(`.utc-preview[data-preview-for="${input.name}"]`);
+  if (!preview) return;
+  const raw = input.value.trim();
+  if (!raw) {
+    preview.textContent = "";
+    preview.classList.remove("utc-preview-error");
+    return;
+  }
+  const d = parseUserDateTime(raw);
+  if (!d) {
+    preview.textContent = "unparseable — expected e.g. 2026-03-30 14:00";
+    preview.classList.add("utc-preview-error");
+    return;
+  }
+  preview.textContent = `= ${formatTime(d.toISOString())} UTC`;
+  preview.classList.remove("utc-preview-error");
+}
+
+function wireUtcPreviews() {
+  document.querySelectorAll("input[data-utc-preview]").forEach(input => {
+    input.addEventListener("input", () => updateUtcPreview(input));
+    updateUtcPreview(input);
+  });
+}
 
 document.getElementById("add-form").addEventListener("submit", (e) => {
   e.preventDefault();
@@ -845,6 +874,7 @@ document.getElementById("auth-login")?.addEventListener("click", () => {
   document.querySelector('#add-form [name="finished_at"]').value = formatTime(new Date().toISOString());
   const filters = readFiltersFromURL();
   populateFormFromFilters(filters);
+  wireUtcPreviews();
 
   const hasFilters = Object.keys(filters).some(k => k !== "detail" && k !== "cursor");
   if (hasFilters) {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -68,9 +68,10 @@
                     </fieldset>
                     <label>Finished at <small>(UTC)</small>
                         <span class="input-with-button">
-                            <input type="text" name="finished_at" placeholder="2026-03-30 14:00 (UTC)">
+                            <input type="text" name="finished_at" placeholder="2026-03-30 14:00 (UTC)" data-utc-preview>
                             <button type="button" id="fill-now" class="secondary outline" title="Fill with current time (UTC)">Now</button>
                         </span>
+                        <small class="utc-preview" data-preview-for="finished_at"></small>
                     </label>
                     <label>Tags
                         <input type="text" name="tags" placeholder="manual,regression">
@@ -115,8 +116,14 @@
                         <label><input type="checkbox" name="result" value="ERROR"> ERROR</label>
                         <label><input type="checkbox" name="result" value="SKIPPED"> SKIPPED</label>
                     </fieldset>
-                    <label>After <small>(UTC)</small> <input type="text" name="finished_after" placeholder="2026-01-01 00:00 (UTC)"></label>
-                    <label>Before <small>(UTC)</small> <input type="text" name="finished_before" placeholder="2026-12-31 23:59 (UTC)"></label>
+                    <label>After <small>(UTC)</small>
+                        <input type="text" name="finished_after" placeholder="2026-01-01 00:00 (UTC)" data-utc-preview>
+                        <small class="utc-preview" data-preview-for="finished_after"></small>
+                    </label>
+                    <label>Before <small>(UTC)</small>
+                        <input type="text" name="finished_before" placeholder="2026-12-31 23:59 (UTC)" data-utc-preview>
+                        <small class="utc-preview" data-preview-for="finished_before"></small>
+                    </label>
                 </div>
                 <div class="grid">
                     <label>Tags <input type="text" name="tags" placeholder="ci,nightly or ~^reg.*"></label>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -414,6 +414,19 @@
     cursor: default;
 }
 
+.utc-preview {
+    display: block;
+    min-height: 1.2em;
+    margin-top: 0.15em;
+    color: var(--pico-muted-color);
+    font-variant-numeric: tabular-nums;
+    font-size: 0.8em;
+}
+
+.utc-preview-error {
+    color: var(--pico-del-color, #c0392b);
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     #results-table th:nth-child(n+5),


### PR DESCRIPTION
## Summary
Closes #22.

The Add and Search forms accept several flexible datetime formats — zoneless (`2026-03-30 14:00`), T-separated, date-only, RFC3339 with offset — and the backend normalizes them all to UTC. Until now, what the user typed and what the API was about to receive could differ silently. This PR adds a small inline hint under each datetime input showing the parsed value as `= YYYY-MM-DD HH:MM UTC`, or an unparseable warning in red when the format is unrecognized.

The preview reuses the existing `parseUserDateTime` / `formatTime` helpers in `app.js`, so it stays consistent with what gets sent to the API.

### Affected fields
- Add tab → `finished_at`
- Search tab → `finished_after`, `finished_before`

Plus a small `.gitignore` addition to keep the local `.claude/` working dir out of the tree.

## Test plan
- [x] Manually verified parser matches Go's `ParseFlexibleTime` for all 7 documented formats (incl. `+02:00` offset → UTC conversion).
- [x] Visually verified in browser:
  - "Now" button populates `finished_at` and the preview updates.
  - Typing `2026-03-30 14:00+02:00` shows `= 2026-03-30 12:00 UTC`.
  - Typing `not-a-date` shows the unparseable warning.
  - "Clear" on the Search form clears previews along with values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)