### PR TITLE
BCR: prefix presubmit targets with @evidence_store_bazel//

### DIFF
--- a/.bcr/adapters/bazel/presubmit.yml
+++ b/.bcr/adapters/bazel/presubmit.yml
@@ -11,10 +11,4 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-      - "//cmd/evidence-bazel"
-  verify_tests:
-    name: Run adapter tests
-    platform: ${{ platform }}
-    bazel: ${{ bazel }}
-    test_targets:
-      - "//..."
+      - "@evidence_store_bazel//cmd/evidence-bazel"


### PR DESCRIPTION
## Summary

- Drop \`verify_tests\` task and prefix the build target with \`@evidence_store_bazel//\` in \`.bcr/adapters/bazel/presubmit.yml\`
- BCR runs presubmits in an *anonymous* Bazel module that just \`bazel_dep\`s us — \`//\` resolves to that empty workspace, not our adapter, which is why all 9 buildkite jobs on [bazelbuild/bazel-central-registry#8566](https://github.com/bazelbuild/bazel-central-registry/pull/8566) failed
- Already pushed the same fix to the open BCR PR's branch directly so 0.0.1 doesn't need a re-release

## Test plan
- [x] Verified \`bazel build @evidence_store_bazel//cmd/evidence-bazel\` succeeds from an anonymous workspace using \`local_path_override\`
- [x] Confirm BCR presubmit goes green on PR #8566 after re-run