### PR TITLE
Restore testify for adapter test targets as a dev dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,18 @@ jobs:
           go-version-file: go.mod
       - name: Build binary
         run: go build -o evidence-store ./cmd/server
+
+  # adapters/bazel is a separate Go module excluded via .bazelignore, so the
+  # jobs above never touch it. Build it the way the BCR presubmit does.
+  bazel-adapter:
+    name: Bazel Adapter
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: adapters/bazel
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and test adapter
+        run: bazel test //...
+      - name: Verify consumer-facing build resolves without dev dependencies
+        run: bazel build --ignore_dev_dependency //cmd/evidence-bazel

--- a/adapters/bazel/MODULE.bazel
+++ b/adapters/bazel/MODULE.bazel
@@ -6,5 +6,23 @@ module(
 
 bazel_dep(name = "rules_go", version = "0.60.0")
 
+# Test-only: the go_test targets need @com_github_stretchr_testify. Marked
+# dev_dependency so consumers pulling evidence_store_bazel from the BCR resolve
+# neither gazelle nor testify, which is what #55 set out to fix.
+#
+# Pinned to 0.40.0 rather than the 0.50.0 used at the repo root: gazelle builds
+# its repository tools with GOTOOLCHAIN=local, and 0.50.0's tools require
+# Go >= 1.24.12 while go.mod pins this module to 1.23.6 for consumers. Being a
+# dev dependency, this version is invisible outside this repo.
+bazel_dep(name = "gazelle", version = "0.40.0", dev_dependency = True)
+
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.from_file(go_mod = "//:go.mod")
+
+go_deps = use_extension(
+    "@gazelle//:extensions.bzl",
+    "go_deps",
+    dev_dependency = True,
+)
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(go_deps, "com_github_stretchr_testify")

--- a/adapters/bazel/MODULE.bazel.lock
+++ b/adapters/bazel/MODULE.bazel.lock
@@ -60,7 +60,8 @@
     "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
     "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
     "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
-    "https://bcr.bazel.build/modules/gazelle/0.36.0/source.json": "0823f097b127e0201ae55d85647c94095edfe27db0431a7ae880dcab08dfaa04",
+    "https://bcr.bazel.build/modules/gazelle/0.40.0/MODULE.bazel": "42ba5378ebe845fca43989a53186ab436d956db498acde790685fe0e8f9c6146",
+    "https://bcr.bazel.build/modules/gazelle/0.40.0/source.json": "1e5ef6e4d8b9b6836d93273c781e78ff829ea2e077afef7a57298040fa4f010a",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -132,6 +133,7 @@
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
+    "https://bcr.bazel.build/modules/rules_go/0.50.1/MODULE.bazel": "b91a308dc5782bb0a8021ad4330c81fea5bda77f96b9e4c117b9b9c8f6665ee0",
     "https://bcr.bazel.build/modules/rules_go/0.60.0/MODULE.bazel": "4a57ff2ffc2a3570e3c5646575c5a4b07287e91bcdac5d1f72383d51502b48cb",
     "https://bcr.bazel.build/modules/rules_go/0.60.0/source.json": "1e21368c5e0c3013a110bd79a8fcff8ca46b5bcb2b561713a7273cbfcff7c464",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
@@ -164,6 +166,7 @@
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
     "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
@@ -206,6 +209,28 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "NRXra7941UfmNUyIxnLt82V5hULluVGL2nBsijTl4j4=",
+        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
+        "recordedInputs": [
+          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
+          "FILE:@@pybind11_bazel+//MODULE.bazel e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+        ],
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.12.0",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
+              ]
+            }
+          }
+        }
+      }
+    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "+Kp6j204mBZ3mxlIDDR0gBoP45BZ4jYRhRAcB8sU0qc=",


### PR DESCRIPTION
## Problem

The `go_test` targets under `adapters/bazel` reference `@com_github_stretchr_testify`, but #55 removed `gazelle` and the `go_deps` extension from the adapter's `MODULE.bazel`. `bazel test //...` in `adapters/bazel` fails analysis on `main` today:

```
ERROR: no such package '@@[unknown repo 'com_github_stretchr_testify' requested from @@]//require'
 ... referenced by '//internal/client:client_test'
```

This is why #52 had to drop the `verify_tests` task from the BCR presubmit. Nothing else covered it either — root CI runs `go test ./internal/...`, which skips `adapters/bazel` because it's a separate Go module, and `.bazelignore` keeps it out of the root Bazel build. So the adapter's tests have not been running anywhere.

## Fix

Re-add `gazelle` and `go_deps` as **dev dependencies**. Consumers resolving `evidence_store_bazel` from the BCR drop dev usages entirely, so #55's goal of a dependency-free module is preserved.

`gazelle` is pinned to `0.40.0` rather than the root's `0.50.0`: gazelle builds its repository tools with `GOTOOLCHAIN=local`, and 0.50.0's tools require Go >= 1.24.12, which conflicts with the `go 1.23.6` that #55 pinned in `go.mod` for consumers. Because it's a dev dependency, this version is invisible outside this repo.

Also adds a `bazel-adapter` CI job so this can't regress silently.

## Verification

Tests now build and pass:

```
//cmd/evidence-bazel:evidence-bazel_test    PASSED
//internal/client:client_test               PASSED
//internal/gitinfo:gitinfo_test             PASSED
//internal/junitxml:junitxml_test           PASSED
//internal/testlogs:testlogs_test           PASSED
//internal/watch:watch_test                 PASSED
Executed 6 out of 6 tests: 6 tests pass.
```

Consumer resolution is unchanged — `bazel mod graph --ignore_dev_dependency` shows only `gazelle@0.36.0`, which `rules_go 0.60.0` already pulls in transitively and did before this change. `bazel build --ignore_dev_dependency //cmd/evidence-bazel` (the target the BCR presubmit builds) still succeeds.

## Follow-ups, not in this PR

- `.bcr/adapters/bazel/presubmit.yml` could get `verify_tests` back, but I couldn't confirm whether BCR presubmit evaluates the module as the root module (dev deps active) or as a dependency (dev deps dropped). It only takes effect at the next release, so it's better verified separately.
- `adapters/bazel/go.mod` still has a direct `require` on `gopkg.in/yaml.v3`, unused since #55 inlined the config parsing.
- Unrelated: the **root** Bazel build is broken — `internal/server/server.go` imports `internal/ratelimit` but `internal/server/BUILD.bazel` lacks the dep, stale since #54. Root CI uses `go build`, so it doesn't catch this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)