### PR TITLE
Add a demo data seeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,25 @@ bazel run //cmd/server               # start the server
 docker compose up -d
 ./scripts/smoke-test.sh
 ```
+
+### Seed demo data
+
+`scripts/seed-demo` fills the database with synthetic evidence for demos and for
+exercising the UI at realistic scale.
+
+```bash
+docker compose up -d db
+go run ./scripts/seed-demo                 # 2,000,000 records (~1 minute)
+go run ./scripts/seed-demo --count 50000   # a smaller set
+go run ./scripts/seed-demo --truncate      # replace existing evidence
+```
+
+It writes to Postgres with `COPY` rather than through the API — the batch
+endpoint inserts one row per round trip, which takes tens of minutes at this
+size. API-level validation is therefore bypassed, so the generator is written to
+produce records that satisfy it anyway.
+
+Records are clustered onto a limited set of repositories, branches and commits so
+that filtering returns meaningful groups, with a realistic verdict distribution
+(88% `PASS`) and timestamps biased towards the recent past. `--seed` makes a run
+reproducible. Two million records occupy roughly 900 MB including indexes.

--- a/scripts/seed-demo/BUILD.bazel
+++ b/scripts/seed-demo/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "seed-demo_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/nesono/evidence-store/scripts/seed-demo",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_jackc_pgx_v5//:pgx",
+        "@com_github_jackc_pgx_v5//pgxpool",
+    ],
+)
+
+go_binary(
+    name = "seed-demo",
+    embed = [":seed-demo_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/scripts/seed-demo/main.go
+++ b/scripts/seed-demo/main.go
@@ -1,0 +1,390 @@
+// Command seed-demo fills an Evidence Store database with synthetic records for
+// demos and manual testing of the web UI.
+//
+// It writes to Postgres directly with COPY rather than going through the API.
+// The batch endpoint inserts one row per round trip (store.InsertBatch), which
+// at two million records takes tens of minutes; COPY takes a couple of minutes.
+// The trade-off is that API-level validation is bypassed, so the generator below
+// is written to satisfy validate.EvidenceCreate on its own.
+//
+// Usage:
+//
+//	go run ./scripts/seed-demo                      # 2,000,000 records
+//	go run ./scripts/seed-demo --count 50000        # a smaller set
+//	go run ./scripts/seed-demo --truncate           # replace existing evidence
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func main() {
+	var (
+		databaseURL = flag.String("database-url", envOrDefault("EVIDENCE_DATABASE_URL",
+			"postgres://evidence:evidence@localhost:5432/evidence_store?sslmode=disable"), "Postgres connection string")
+		count    = flag.Int("count", 2_000_000, "Number of records to generate")
+		batch    = flag.Int("batch", 50_000, "Rows per COPY batch")
+		days     = flag.Int("days", 180, "Spread finished_at over this many days back from now")
+		repos    = flag.Int("repos", 12, "Number of distinct repositories to generate")
+		seed     = flag.Int64("seed", 1, "Random seed; the same seed produces the same data")
+		truncate = flag.Bool("truncate", false, "Delete all existing evidence first")
+	)
+	flag.Parse()
+
+	if *count <= 0 || *batch <= 0 || *days <= 0 || *repos <= 0 {
+		fmt.Fprintln(os.Stderr, "error: --count, --batch, --days and --repos must all be positive")
+		os.Exit(1)
+	}
+
+	// Ctrl-C stops cleanly between batches; rows already copied stay committed.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, *databaseURL, *count, *batch, *days, *repos, *seed, *truncate); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, databaseURL string, count, batch, days, repoCount int, seed int64, truncate bool) error {
+	cfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return fmt.Errorf("parse database url: %w", err)
+	}
+	// `result` is a Postgres enum. COPY uses the binary protocol, so pgx needs the
+	// type registered on each connection before it can encode a Go string into it.
+	cfg.AfterConnect = func(ctx context.Context, c *pgx.Conn) error {
+		t, err := c.LoadType(ctx, "evidence_result")
+		if err != nil {
+			return fmt.Errorf("load evidence_result enum: %w", err)
+		}
+		c.TypeMap().RegisterType(t)
+		return nil
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer pool.Close()
+
+	if err := pool.Ping(ctx); err != nil {
+		return fmt.Errorf("ping database: %w", err)
+	}
+
+	var existing int64
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM evidence").Scan(&existing); err != nil {
+		return fmt.Errorf("count existing evidence: %w", err)
+	}
+
+	if truncate {
+		fmt.Printf("deleting %s existing record(s)...\n", humanize(existing))
+		if _, err := pool.Exec(ctx, "TRUNCATE evidence"); err != nil {
+			return fmt.Errorf("truncate evidence: %w", err)
+		}
+		existing = 0
+	} else if existing > 0 {
+		fmt.Printf("note: %s record(s) already present; adding to them (use --truncate to replace)\n", humanize(existing))
+	}
+
+	g := newGenerator(seed, days, repoCount)
+
+	fmt.Printf("seeding %s records into %s\n", humanize(int64(count)), redactPassword(databaseURL))
+	start := time.Now()
+	written := 0
+
+	for written < count {
+		n := min(batch, count-written)
+
+		rows, err := pool.CopyFrom(ctx,
+			pgx.Identifier{"evidence"},
+			[]string{"repo", "branch", "rcs_ref", "procedure_ref", "evidence_type", "source", "result", "finished_at", "ingested_at", "metadata"},
+			pgx.CopyFromSlice(n, func(int) ([]any, error) { return g.row(), nil }),
+		)
+		if err != nil {
+			if ctx.Err() != nil {
+				fmt.Printf("\ninterrupted after %s records\n", humanize(int64(written)))
+				return nil
+			}
+			return fmt.Errorf("copy batch: %w", err)
+		}
+		written += int(rows)
+
+		elapsed := time.Since(start)
+		rate := float64(written) / elapsed.Seconds()
+		eta := time.Duration(float64(count-written)/rate) * time.Second
+		fmt.Printf("\r  %s / %s (%.0f rows/s, eta %s)      ",
+			humanize(int64(written)), humanize(int64(count)), rate, eta.Round(time.Second))
+	}
+	fmt.Println()
+
+	// Without fresh statistics the planner mis-estimates the COUNT(*) and sorts
+	// the UI issues, which makes a freshly seeded demo look slower than it is.
+	fmt.Print("analyzing table... ")
+	if _, err := pool.Exec(ctx, "ANALYZE evidence"); err != nil {
+		return fmt.Errorf("analyze: %w", err)
+	}
+	fmt.Println("done")
+
+	fmt.Printf("\nseeded %s records in %s\n", humanize(int64(written)), time.Since(start).Round(time.Second))
+	return summarize(ctx, pool)
+}
+
+// summarize prints what was generated so the demo driver knows what to filter on.
+func summarize(ctx context.Context, pool *pgxpool.Pool) error {
+	var total int64
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM evidence").Scan(&total); err != nil {
+		return fmt.Errorf("count evidence: %w", err)
+	}
+	fmt.Printf("\ntable now holds %s records\n", humanize(total))
+
+	rows, err := pool.Query(ctx, `
+		SELECT repo, COUNT(*) FROM evidence GROUP BY repo ORDER BY COUNT(*) DESC LIMIT 5
+	`)
+	if err != nil {
+		return fmt.Errorf("summarize repos: %w", err)
+	}
+	defer rows.Close()
+
+	fmt.Println("\ntop repositories:")
+	for rows.Next() {
+		var repo string
+		var n int64
+		if err := rows.Scan(&repo, &n); err != nil {
+			return err
+		}
+		fmt.Printf("  %-32s %s\n", repo, humanize(n))
+	}
+	return rows.Err()
+}
+
+// ---------------------------------------------------------------------------
+// Generator
+// ---------------------------------------------------------------------------
+
+// generator produces records that look like real CI output: mostly passing,
+// clustered onto a limited set of repos, branches and commits so that filtering
+// in the UI returns meaningful groups rather than one row per value.
+type generator struct {
+	rnd      *rand.Rand
+	repos    []string
+	commits  [][]string // per repo, so a commit filter selects one repo's run
+	now      time.Time
+	spread   time.Duration
+	branches []string
+	types    []string
+	sources  []string
+	packages []string
+	targets  []string
+	tags     []string
+}
+
+func newGenerator(seed int64, days, repoCount int) *generator {
+	rnd := rand.New(rand.NewSource(seed))
+
+	orgs := []string{"nesono", "acme", "globex", "initech"}
+	names := []string{
+		"evidence-store", "payments-api", "web-frontend", "data-pipeline",
+		"auth-service", "mobile-app", "infra-tooling", "search-index",
+		"billing-worker", "notification-hub", "reporting", "gateway",
+	}
+
+	g := &generator{
+		rnd:    rnd,
+		now:    time.Now().UTC(),
+		spread: time.Duration(days) * 24 * time.Hour,
+		branches: []string{
+			"main", "main", "main", "main", "main", "main", "main",
+			"develop", "develop",
+			"release/2.4", "release/2.5",
+			"feature/checkout-v2", "feature/oauth-refresh", "feature/dark-mode",
+		},
+		// Must satisfy validate.EvidenceCreate's ^[a-z][a-z0-9_]{0,63}$ pattern.
+		types: []string{"bazel", "bazel", "bazel", "bazel", "pytest", "gotest", "junit", "manual"},
+		sources: []string{
+			"https://ci.example.com/build/4711", "https://ci.example.com/build/4712",
+			"https://github.com/nesono/evidence_store/actions/runs/30207857523",
+			"jenkins-agent-03", "buildkite-agent-11", "alice", "bob", "carol",
+		},
+		packages: []string{
+			"//internal/api", "//internal/store", "//internal/auth", "//internal/model",
+			"//internal/retention", "//internal/validate", "//internal/ratelimit",
+			"//cmd/server", "//web", "//adapters/bazel/internal/watch", "//tests",
+		},
+		targets: []string{
+			"unit_test", "integration_test", "smoke_test", "regression_test",
+			"golden_test", "e2e_test", "contract_test", "fuzz_test",
+		},
+		tags: []string{"ci", "nightly", "regression", "smoke", "flaky", "slow", "critical", "local", "dev"},
+	}
+
+	for i := range repoCount {
+		g.repos = append(g.repos, fmt.Sprintf("%s/%s",
+			orgs[i%len(orgs)], names[i%len(names)]))
+
+		// Each repo gets a pool of commits, so filtering by one commit returns a
+		// realistic single build's worth of results rather than a lone record.
+		commits := make([]string, 40)
+		for j := range commits {
+			commits[j] = randomHex(rnd, 40)
+		}
+		g.commits = append(g.commits, commits)
+	}
+
+	return g
+}
+
+func (g *generator) row() []any {
+	repoIdx := g.rnd.Intn(len(g.repos))
+	repo := g.repos[repoIdx]
+	commit := g.commits[repoIdx][g.rnd.Intn(len(g.commits[repoIdx]))]
+
+	result := g.result()
+
+	// Bias timestamps towards the recent past, the way an active repo's history
+	// looks: dense near today, thinning out further back.
+	age := time.Duration(g.rnd.Float64() * g.rnd.Float64() * float64(g.spread))
+	finishedAt := g.now.Add(-age)
+	// Results are ingested shortly after the run finishes. The default list
+	// ordering is by ingested_at, so this keeps that ordering meaningful.
+	ingestedAt := finishedAt.Add(time.Duration(g.rnd.Intn(600)+5) * time.Second)
+
+	procedure := fmt.Sprintf("%s:%s",
+		g.packages[g.rnd.Intn(len(g.packages))],
+		g.targets[g.rnd.Intn(len(g.targets))])
+
+	return []any{
+		repo,
+		g.branches[g.rnd.Intn(len(g.branches))],
+		commit,
+		procedure,
+		g.types[g.rnd.Intn(len(g.types))],
+		g.sources[g.rnd.Intn(len(g.sources))],
+		result,
+		finishedAt,
+		ingestedAt,
+		g.metadata(result, procedure),
+	}
+}
+
+// result returns a realistic verdict distribution: mostly green, with enough
+// failures to make the result filter worth using.
+func (g *generator) result() string {
+	switch n := g.rnd.Intn(100); {
+	case n < 88:
+		return "PASS"
+	case n < 95:
+		return "FAIL"
+	case n < 98:
+		return "ERROR"
+	default:
+		return "SKIPPED"
+	}
+}
+
+func (g *generator) metadata(result, procedure string) []byte {
+	meta := map[string]any{
+		"tags":        g.pickTags(),
+		"duration_ms": g.rnd.Intn(120_000) + 40,
+	}
+
+	switch result {
+	case "FAIL":
+		meta["notes"] = fmt.Sprintf("assertion failed in %s: expected 200, got %d",
+			procedure, []int{400, 403, 404, 409, 500, 503}[g.rnd.Intn(6)])
+	case "ERROR":
+		meta["notes"] = []string{
+			"test binary crashed: signal SIGSEGV",
+			"timed out after 300s",
+			"could not connect to test database",
+			"out of memory",
+		}[g.rnd.Intn(4)]
+	case "SKIPPED":
+		meta["notes"] = "skipped: requires docker"
+	}
+
+	b, err := json.Marshal(meta)
+	if err != nil {
+		// The map holds only strings, ints and []string, so this cannot fail.
+		panic(err)
+	}
+	return b
+}
+
+func (g *generator) pickTags() []string {
+	n := g.rnd.Intn(3) + 1
+	picked := make([]string, 0, n)
+	for range n {
+		t := g.tags[g.rnd.Intn(len(g.tags))]
+		if !contains(picked, t) {
+			picked = append(picked, t)
+		}
+	}
+	return picked
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const hexDigits = "0123456789abcdef"
+
+func randomHex(rnd *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = hexDigits[rnd.Intn(len(hexDigits))]
+	}
+	return string(b)
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// humanize formats n with thousands separators, matching how the UI reads.
+func humanize(n int64) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	var parts []string
+	for len(s) > 3 {
+		parts = append([]string{s[len(s)-3:]}, parts...)
+		s = s[:len(s)-3]
+	}
+	return s + "," + strings.Join(parts, ",")
+}
+
+// redactPassword strips credentials so the connection string can be printed.
+func redactPassword(url string) string {
+	at := strings.LastIndex(url, "@")
+	slashes := strings.Index(url, "//")
+	if at == -1 || slashes == -1 || at < slashes {
+		return url
+	}
+	return url[:slashes+2] + "***@" + url[at+1:]
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}


### PR DESCRIPTION
Exercising the UI at realistic scale needs a lot of records, and there was no way to produce them.

```bash
docker compose up -d db
go run ./scripts/seed-demo                 # 2,000,000 records (~1 minute)
go run ./scripts/seed-demo --count 50000   # a smaller set
go run ./scripts/seed-demo --truncate      # replace existing evidence
```

## Why COPY instead of the API

The batch endpoint inserts one row per round trip (`store.InsertBatch`), which takes tens of minutes at two million records; `COPY` takes about one. The trade-off is that API-level validation is bypassed, so the generator is written to satisfy `validate.EvidenceCreate` on its own — notably the `evidence_type` `^[a-z][a-z0-9_]{0,63}$` pattern.

`result` is a Postgres enum and `COPY` uses the binary protocol, so the pool registers the enum type on each connection via `AfterConnect` before pgx can encode into it.

## Data shape

Shaped for demonstrating filters rather than being uniformly random:

- 12 repositories × 40 commits each, so filtering by a commit returns one build's worth of results instead of a lone record.
- Realistic verdicts — 88% `PASS`, 7% `FAIL`, 3% `ERROR`, 2% `SKIPPED` — with plausible `notes` on the failures.
- `finished_at` biased towards the recent past, the way an active repo's history looks.
- `ingested_at` trails `finished_at` by 5s–10min, so the default list ordering (by `ingested_at`) reflects something plausible rather than being arbitrary.
- `--seed` makes a run reproducible; `ANALYZE` runs at the end so a freshly seeded database doesn't plan from empty statistics.

## Safety

`--truncate` is opt-in; the default appends and reports how many records were already present. Ctrl-C stops cleanly between batches.

## Testing

Ran against a local Postgres: 2,000,000 records in 65s (~31k rows/s sustained), occupying 906 MB including indexes. Verified the generated distributions (5 evidence types, 96 procedures, ~413 commits, results matching the intended weights, timestamps spread over the requested window) and that `go vet ./...` and `bazel build //scripts/seed-demo` are clean.

Worth knowing: at two million rows `COUNT(*)` is ~50ms and filtered queries are <100ms, but a deep unfiltered `OFFSET` is slow (~5.8s at offset 2M). That's a property of offset pagination, not of this script — it's being addressed in the UI work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)