### PR TITLE
Rework the search UI around a windowed result view

### DIFF
--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -233,7 +233,10 @@ func (s *EvidenceStore) List(ctx context.Context, params ListParams) (*ListResul
 		if params.Desc {
 			direction = "DESC"
 		}
-		query += fmt.Sprintf(" ORDER BY %s %s, id ASC", params.Sort, direction)
+		// The tie-break follows the sort direction so that descending is the exact
+		// reverse of ascending. Clients rely on that to read a window near the end
+		// of a large result set from the far end, avoiding a deep OFFSET scan.
+		query += fmt.Sprintf(" ORDER BY %s %s, id %s", params.Sort, direction, direction)
 	}
 
 	query += fmt.Sprintf(" LIMIT %s", arg(params.Limit+1))

--- a/tests/list_offset_sort_test.go
+++ b/tests/list_offset_sort_test.go
@@ -253,6 +253,54 @@ func TestListEvidenceSortIsStableAcrossWindows(t *testing.T) {
 	assert.Len(t, seen, 6, "every record must appear exactly once across the windows")
 }
 
+func TestReversedWindowMatchesDirectWindow(t *testing.T) {
+	repo := "org/reverse_" + uuid.New().String()[:8]
+
+	// Two batches. Every record within a batch shares ingested_at, because now()
+	// is the transaction timestamp, so the id tie-break alone decides their order.
+	// Reading a window from the far end has to reverse cleanly through those ties,
+	// which is what lets the UI jump to the last window without a deep OFFSET.
+	for b := range 2 {
+		var records []model.EvidenceCreate
+		for i := range 10 {
+			records = append(records, makeEvidence(
+				repo, "main", "rev123", fmt.Sprintf("//pkg:b%d_t%d", b, i), "ci", model.ResultPass))
+		}
+		resp := postJSON(t, "/api/v1/evidence/batch", model.BatchRequest{Records: records})
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	const total, size = 20, 4
+
+	for offset := 0; offset+size <= total; offset += size {
+		resp := getJSON(t, fmt.Sprintf(
+			"/api/v1/evidence?repo=%s&limit=%d&offset=%d&sort=ingested_at&order=asc", repo, size, offset))
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		direct := decodeJSON[listResponse](t, resp)
+		require.Len(t, direct.Records, size)
+
+		// The same window, approached from the opposite end.
+		resp = getJSON(t, fmt.Sprintf(
+			"/api/v1/evidence?repo=%s&limit=%d&offset=%d&sort=ingested_at&order=desc",
+			repo, size, total-offset-size))
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		reversed := decodeJSON[listResponse](t, resp)
+		require.Len(t, reversed.Records, size)
+
+		want := make([]uuid.UUID, 0, size)
+		for _, r := range direct.Records {
+			want = append(want, r.ID)
+		}
+		got := make([]uuid.UUID, 0, size)
+		for i := len(reversed.Records) - 1; i >= 0; i-- {
+			got = append(got, reversed.Records[i].ID)
+		}
+		assert.Equal(t, want, got,
+			"window at offset %d read from the far end must match the direct read", offset)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Tests: Inherited records are kept out of the window
 // ---------------------------------------------------------------------------

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,43 +1,93 @@
 const API_BASE = "/api/v1";
 
-const TEXT_FIELDS = [
-  "repo", "branch", "rcs_ref", "evidence_type", "source", "procedure_ref", "tags", "notes",
-];
+// Fields shown in the collapsed bar; everything else lives behind "More filters".
+const BAR_TEXT_FIELDS = ["repo", "rcs_ref"];
+const ADVANCED_TEXT_FIELDS = ["branch", "evidence_type", "source", "procedure_ref", "tags", "notes"];
+const TEXT_FIELDS = [...BAR_TEXT_FIELDS, ...ADVANCED_TEXT_FIELDS];
 const DATETIME_FIELDS = ["finished_after", "finished_before"];
+// Badged onto the toggle, so a collapsed panel never hides an applied constraint.
+const ADVANCED_FIELDS = [...ADVANCED_TEXT_FIELDS, ...DATETIME_FIELDS, "include_inherited"];
 
-let cursorStack = [];
-let currentCursor = null;
-let currentTotal = null;
+// The list endpoint's default ordering. Named because reading a window from the
+// far end has to ask for the exact reverse of it.
+const DEFAULT_SORT_COLUMN = "ingested_at";
+
+const WINDOW_SIZES = [25, 50, 100, 200, 500];
+const DEFAULT_WINDOW_SIZE = 50;
+
+// The current window into the result set.
+let windowOffset = 0;
+let windowSize = DEFAULT_WINDOW_SIZE;
+let sortColumn = "";     // "" means the API's default ordering
+let sortDesc = false;
+let totalRecords = null; // cached, so only a filter change pays for the COUNT(*)
+
+// --- Preferences ---
+
+const WINDOW_SIZE_KEY = "evidence_window_size";
+
+function loadPref(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw === null ? fallback : JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function savePref(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch { /* storage unavailable (private mode); preference just won't persist */ }
+}
+
+function normalizeWindowSize(n) {
+  return WINDOW_SIZES.includes(n) ? n : DEFAULT_WINDOW_SIZE;
+}
 
 // --- URL State ---
 
-function readFiltersFromURL() {
+function readStateFromURL() {
   const params = new URLSearchParams(window.location.search);
   const filters = {};
-  for (const f of TEXT_FIELDS) {
-    if (params.has(f)) filters[f] = params.get(f);
-  }
-  for (const f of DATETIME_FIELDS) {
+  for (const f of [...TEXT_FIELDS, ...DATETIME_FIELDS]) {
     if (params.has(f)) filters[f] = params.get(f);
   }
   if (params.has("result")) filters.result = params.get("result");
-  if (params.has("limit")) filters.limit = params.get("limit");
   if (params.has("include_inherited")) filters.include_inherited = params.get("include_inherited");
-  if (params.has("cursor")) filters.cursor = params.get("cursor");
-  if (params.has("detail")) filters.detail = params.get("detail");
-  return filters;
+
+  const offset = parseInt(params.get("offset"), 10);
+  windowOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;
+
+  const limit = parseInt(params.get("limit"), 10);
+  windowSize = Number.isFinite(limit)
+    ? normalizeWindowSize(limit)
+    : normalizeWindowSize(loadPref(WINDOW_SIZE_KEY, DEFAULT_WINDOW_SIZE));
+
+  sortColumn = params.get("sort") || "";
+  sortDesc = params.get("order") === "desc";
+
+  // A `cursor=` from an older link is deliberately ignored. It is an opaque
+  // position marker: it cannot say which window it refers to, so the view would
+  // have no range to show and no way back. Those links open at the first window.
+  return { filters, detail: params.get("detail") };
 }
 
-function writeFiltersToURL(filters) {
+function writeStateToURL(filters, detail) {
   const params = new URLSearchParams();
   for (const [k, v] of Object.entries(filters)) {
     if (v !== "" && v !== null && v !== undefined) {
       params.set(k, v);
     }
   }
-  const qs = params.toString();
-  const url = qs ? `?${qs}` : window.location.pathname;
-  history.pushState(null, "", url);
+  if (windowOffset > 0) params.set("offset", String(windowOffset));
+  params.set("limit", String(windowSize));
+  if (sortColumn) {
+    params.set("sort", sortColumn);
+    params.set("order", sortDesc ? "desc" : "asc");
+  }
+  if (detail) params.set("detail", detail);
+  history.pushState(null, "", `?${params}`);
 }
 
 function populateFormFromFilters(filters) {
@@ -48,18 +98,19 @@ function populateFormFromFilters(filters) {
   }
   for (const f of DATETIME_FIELDS) {
     const input = form.querySelector(`[name="${f}"]`);
-    if (input && filters[f]) {
-      const d = parseUserDateTime(filters[f]);
-      input.value = d ? formatTime(d.toISOString()) : filters[f];
+    if (input) {
+      if (filters[f]) {
+        const d = parseUserDateTime(filters[f]);
+        input.value = d ? formatTime(d.toISOString()) : filters[f];
+      } else {
+        input.value = "";
+      }
     }
   }
-  const resultChecks = form.querySelectorAll('[name="result"]');
   const activeResults = (filters.result || "").split(",").filter(Boolean);
-  resultChecks.forEach(cb => {
+  form.querySelectorAll('[name="result"]').forEach(cb => {
     cb.checked = activeResults.includes(cb.value);
   });
-  const limitInput = form.querySelector('[name="limit"]');
-  if (limitInput) limitInput.value = filters.limit || "";
   const inheritedInput = form.querySelector('[name="include_inherited"]');
   if (inheritedInput) inheritedInput.checked = filters.include_inherited !== "false";
 }
@@ -80,12 +131,44 @@ function readFormFilters() {
   }
   const results = Array.from(form.querySelectorAll('[name="result"]:checked')).map(cb => cb.value);
   if (results.length > 0) filters.result = results.join(",");
-  const limit = form.querySelector('[name="limit"]').value;
-  if (limit) filters.limit = limit;
   if (!form.querySelector('[name="include_inherited"]').checked) {
     filters.include_inherited = "false";
   }
   return filters;
+}
+
+// --- Filter panel ---
+
+function activeAdvancedCount(filters) {
+  let n = 0;
+  for (const f of ADVANCED_FIELDS) {
+    if (f === "include_inherited") {
+      if (filters.include_inherited === "false") n++;
+    } else if (filters[f]) {
+      n++;
+    }
+  }
+  return n;
+}
+
+function advancedExpanded() {
+  return document.getElementById("toggle-advanced").getAttribute("aria-expanded") === "true";
+}
+
+function setAdvancedExpanded(expanded) {
+  document.getElementById("filter-advanced").hidden = !expanded;
+  document.getElementById("toggle-advanced").setAttribute("aria-expanded", String(expanded));
+  refreshAdvancedToggle();
+}
+
+function refreshAdvancedToggle() {
+  const btn = document.getElementById("toggle-advanced");
+  if (advancedExpanded()) {
+    btn.textContent = "Fewer filters";
+    return;
+  }
+  const n = activeAdvancedCount(readFormFilters());
+  btn.textContent = n > 0 ? `More filters (${n})` : "More filters";
 }
 
 // --- Auth ---
@@ -137,20 +220,60 @@ async function apiFetch(url, options = {}) {
 
 // --- API ---
 
-async function fetchEvidence(filters, cursor) {
+// fetchWindow retrieves the current window of records.
+//
+// A window near the end of a large result set is expensive to read directly:
+// OFFSET makes Postgres walk every skipped row, which at two million records
+// costs seconds. Approaching from whichever end is closer keeps that walk short,
+// so jumping to the last window is as cheap as the first. This relies on
+// descending order being the exact reverse of ascending, which holds because the
+// API's id tie-break follows the sort direction.
+async function fetchWindow(filters) {
   const params = new URLSearchParams();
   for (const [k, v] of Object.entries(filters)) {
-    if (k === "detail") continue;
     if (v !== "" && v !== null && v !== undefined) {
       params.set(k, v);
     }
   }
-  if (cursor) params.set("cursor", cursor);
-  if (!params.has("limit")) params.set("limit", "50");
+
+  // The total only changes when the filters do, so it is fetched once and cached.
+  if (totalRecords === null) {
+    params.set("include_total", "true");
+  } else {
+    params.set("include_total", "false");
+  }
+
+  let limit = windowSize;
+  let offset = windowOffset;
+  const fromFarEnd = totalRecords !== null && windowOffset > totalRecords / 2;
+
+  if (fromFarEnd) {
+    limit = Math.min(windowSize, Math.max(0, totalRecords - windowOffset));
+    offset = Math.max(0, totalRecords - windowOffset - limit);
+  }
+
+  if (limit <= 0) {
+    // Window sits entirely past the end; let the caller clamp and retry.
+    return { records: [], total: totalRecords };
+  }
+
+  params.set("limit", String(limit));
+  if (offset > 0) params.set("offset", String(offset));
+
+  if (fromFarEnd || sortColumn) {
+    params.set("sort", sortColumn || DEFAULT_SORT_COLUMN);
+    const desc = fromFarEnd ? !sortDesc : sortDesc;
+    params.set("order", desc ? "desc" : "asc");
+  }
 
   const resp = await apiFetch(`${API_BASE}/evidence?${params}`);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
-  return resp.json();
+  const data = await resp.json();
+
+  if (fromFarEnd && data.records) {
+    data.records = data.records.slice().reverse();
+  }
+  return data;
 }
 
 async function fetchEvidenceById(id) {
@@ -233,45 +356,79 @@ function parseUserDateTime(str) {
   return isNaN(d.getTime()) ? null : d;
 }
 
+function rowHTML(r) {
+  const branch = r.branch || "";
+  return `
+    <tr data-id="${r.id}" class="${r.inherited ? "inherited-row" : ""}">
+      <td class="col-result">${resultBadge(r.result)}</td>
+      <td class="col-procedure" title="${esc(r.procedure_ref)}">${esc(r.procedure_ref)}</td>
+      <td class="col-repo" title="${esc(r.repo)}">${esc(r.repo)}</td>
+      <td class="col-branch" title="${esc(branch)}">${esc(branch)}</td>
+      <td class="col-commit commit-ref">${esc((r.rcs_ref || "").slice(0, 10))}</td>
+      <td class="col-type">${esc(r.evidence_type)}</td>
+      <td class="col-source" title="${esc(r.source)}">${esc(r.source)}</td>
+      <td class="col-finished">${formatTime(r.finished_at)}</td>
+      <td class="col-tags">${renderTags(r.metadata)}</td>
+    </tr>`;
+}
+
 function renderTable(records) {
   const tbody = document.getElementById("results-body");
   if (!records || records.length === 0) {
-    tbody.innerHTML = `<tr><td colspan="9" class="empty-state">No records found</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="9" class="empty-state">No records match these filters</td></tr>`;
     return;
   }
-  tbody.innerHTML = records.map(r => `
-    <tr data-id="${r.id}" class="${r.inherited ? "inherited-row" : ""}">
-      <td>${resultBadge(r.result)}</td>
-      <td>${esc(r.procedure_ref)}</td>
-      <td>${esc(r.repo)}</td>
-      <td>${esc(r.branch || "")}</td>
-      <td class="commit-ref">${esc((r.rcs_ref || "").slice(0, 10))}</td>
-      <td>${esc(r.evidence_type)}</td>
-      <td>${esc(r.source)}</td>
-      <td>${formatTime(r.finished_at)}</td>
-      <td>${renderTags(r.metadata)}</td>
-    </tr>
-  `).join("");
+  tbody.innerHTML = records.map(rowHTML).join("");
+  // Each window starts at its own top rather than inheriting the previous scroll.
+  document.getElementById("results-window").scrollTop = 0;
 }
 
-function renderSummary(pageCount, total, hasMore) {
+// Inherited records are resolved outside the paginated window, so they are listed
+// separately and left out of the range readout.
+function renderInherited(records) {
+  const panel = document.getElementById("inherited-panel");
+  if (!records || records.length === 0) {
+    panel.hidden = true;
+    document.getElementById("inherited-body").innerHTML = "";
+    return;
+  }
+  panel.hidden = false;
+  document.getElementById("inherited-count").textContent = records.length.toLocaleString();
+  document.getElementById("inherited-body").innerHTML = records.map(rowHTML).join("");
+}
+
+function renderRange(count) {
   const el = document.getElementById("results-summary");
-  if (total !== null && total !== undefined) {
-    if (total === pageCount) {
-      el.textContent = `${total} record${total !== 1 ? "s" : ""}`;
-    } else {
-      el.textContent = `showing ${pageCount} of ${total} records`;
-    }
+  const n = x => x.toLocaleString();
+
+  if (count === 0) {
+    el.textContent = totalRecords ? `no records in this window of ${n(totalRecords)}` : "no records";
     return;
   }
-  const suffix = hasMore ? "+" : "";
-  el.textContent = `${pageCount}${suffix} record${pageCount !== 1 ? "s" : ""}`;
+  const from = windowOffset + 1;
+  const to = windowOffset + count;
+
+  if (totalRecords === null) {
+    el.textContent = `${n(from)}–${n(to)}`;
+  } else if (windowOffset === 0 && count === totalRecords) {
+    el.textContent = `${n(totalRecords)} record${totalRecords !== 1 ? "s" : ""}`;
+  } else {
+    el.textContent = `${n(from)}–${n(to)} of ${n(totalRecords)} records`;
+  }
 }
 
-function renderPagination(nextCursor) {
-  currentCursor = nextCursor;
-  document.getElementById("next-page").disabled = !nextCursor;
-  document.getElementById("prev-page").disabled = cursorStack.length === 0;
+function lastWindowOffset() {
+  if (!totalRecords) return 0;
+  return Math.max(0, Math.floor((totalRecords - 1) / windowSize) * windowSize);
+}
+
+function renderWindowNav() {
+  const atStart = windowOffset === 0;
+  const atEnd = totalRecords === null || windowOffset >= lastWindowOffset();
+  document.getElementById("first-window").disabled = atStart;
+  document.getElementById("prev-page").disabled = atStart;
+  document.getElementById("next-page").disabled = atEnd;
+  document.getElementById("last-window").disabled = atEnd;
 }
 
 function renderDetail(record) {
@@ -315,105 +472,154 @@ function esc(str) {
 
 // --- Search ---
 
-async function doSearch(filters, cursor) {
+async function doSearch(filters, { clamped = false } = {}) {
   const tbody = document.getElementById("results-body");
   tbody.innerHTML = `<tr><td colspan="9" class="empty-state">Loading...</td></tr>`;
 
-  // Fresh first-page fetch invalidates any previously cached total.
-  if (!cursor) {
-    currentTotal = null;
-  }
-
   try {
-    const data = await fetchEvidence(filters, cursor);
-    // Inherited records are returned outside the paginated window so they cannot
-    // distort its range; this view lists them inline after the window's records.
-    const records = data.records || [];
-    const inherited = data.inherited_records || [];
-    renderTable([...records, ...inherited]);
-    // The API only returns `total` on the first page; preserve it across subsequent page fetches.
+    const data = await fetchWindow(filters);
     if (data.total !== undefined && data.total !== null) {
-      currentTotal = data.total;
+      totalRecords = data.total;
     }
-    renderSummary(records.length + inherited.length, currentTotal, !!data.next_cursor);
-    renderPagination(data.next_cursor || null);
+
+    // The requested window can sit past the end — a stale deep link, a smaller
+    // result set than last time, or a larger window size. Clamp once and refetch.
+    if (!clamped && totalRecords !== null && windowOffset > 0 && windowOffset >= totalRecords) {
+      windowOffset = lastWindowOffset();
+      writeStateToURL(filters);
+      return doSearch(filters, { clamped: true });
+    }
+
+    renderTable(data.records);
+    renderInherited(data.inherited_records);
+    renderRange((data.records || []).length);
+    renderWindowNav();
   } catch (err) {
     tbody.innerHTML = `<tr><td colspan="9" class="empty-state">Error: ${esc(err.message)}</td></tr>`;
-    renderSummary(0, null, false);
-    renderPagination(null);
+    document.getElementById("results-summary").textContent = "";
+    renderInherited(null);
+    renderWindowNav();
   }
+}
+
+// Re-runs the search from the first window, discarding the cached total because
+// changing the filters changes the count.
+function search() {
+  windowOffset = 0;
+  totalRecords = null;
+  const filters = readFormFilters();
+  refreshAdvancedToggle();
+  writeStateToURL(filters);
+  doSearch(filters);
+}
+
+// Moves the window without re-counting — the filters, and so the total, are
+// unchanged.
+function moveWindow(offset) {
+  const target = Math.max(0, Math.min(offset, lastWindowOffset()));
+  if (target === windowOffset) return;
+  windowOffset = target;
+  const filters = readFormFilters();
+  writeStateToURL(filters);
+  doSearch(filters);
 }
 
 // --- Events ---
 
 document.getElementById("filter-form").addEventListener("submit", (e) => {
   e.preventDefault();
-  cursorStack = [];
-  const filters = readFormFilters();
-  writeFiltersToURL(filters);
-  doSearch(filters, null);
+  search();
 });
 
 document.getElementById("clear-filters").addEventListener("click", () => {
   const form = document.getElementById("filter-form");
   form.reset();
   form.querySelectorAll("input[data-utc-preview]").forEach(updateUtcPreview);
-  cursorStack = [];
-  writeFiltersToURL({});
-  document.getElementById("results-body").innerHTML =
-    `<tr><td colspan="9" class="empty-state">Enter filters and click Search</td></tr>`;
-  document.getElementById("results-summary").textContent = "";
-  renderPagination(null);
+  search();
 });
 
-document.getElementById("next-page").addEventListener("click", () => {
-  if (!currentCursor) return;
-  const filters = readFormFilters();
-  cursorStack.push(filters.cursor || null);
-  filters.cursor = currentCursor;
-  writeFiltersToURL(filters);
-  doSearch(filters, currentCursor);
+document.getElementById("toggle-advanced").addEventListener("click", () => {
+  setAdvancedExpanded(!advancedExpanded());
 });
 
-document.getElementById("prev-page").addEventListener("click", () => {
-  if (cursorStack.length === 0) return;
+document.getElementById("first-window").addEventListener("click", () => moveWindow(0));
+document.getElementById("prev-page").addEventListener("click", () => moveWindow(windowOffset - windowSize));
+document.getElementById("next-page").addEventListener("click", () => moveWindow(windowOffset + windowSize));
+document.getElementById("last-window").addEventListener("click", () => moveWindow(lastWindowOffset()));
+
+document.getElementById("window-size").addEventListener("change", (e) => {
+  const size = normalizeWindowSize(parseInt(e.target.value, 10));
+  // Keep the first record of the current window visible across the size change,
+  // so the view stays roughly where the user was rather than jumping to the top.
+  const anchor = windowOffset;
+  windowSize = size;
+  savePref(WINDOW_SIZE_KEY, size);
+  windowOffset = Math.floor(anchor / size) * size;
   const filters = readFormFilters();
-  const prevCursor = cursorStack.pop();
-  if (prevCursor) {
-    filters.cursor = prevCursor;
-  } else {
-    delete filters.cursor;
+  writeStateToURL(filters);
+  doSearch(filters);
+});
+
+// Window navigation from the keyboard, ignored while typing in the filter form.
+document.addEventListener("keydown", (e) => {
+  if (e.ctrlKey || e.metaKey || e.altKey) return;
+  const tag = e.target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+  if (document.querySelector("dialog[open]")) return;
+  if (document.getElementById("tab-search").hidden) return;
+
+  switch (e.key) {
+    case "PageDown": moveWindow(windowOffset + windowSize); break;
+    case "PageUp":   moveWindow(windowOffset - windowSize); break;
+    case "Home":     moveWindow(0); break;
+    case "End":      moveWindow(lastWindowOffset()); break;
+    default: return;
   }
-  writeFiltersToURL(filters);
-  doSearch(filters, prevCursor);
+  e.preventDefault();
 });
 
-document.getElementById("results-body").addEventListener("click", async (e) => {
-  const row = e.target.closest("tr[data-id]");
-  if (!row) return;
+async function openDetail(id) {
   try {
-    const record = await fetchEvidenceById(row.dataset.id);
+    const record = await fetchEvidenceById(id);
     renderDetail(record);
-    const filters = readFormFilters();
-    filters.detail = row.dataset.id;
-    writeFiltersToURL(filters);
+    writeStateToURL(readFormFilters(), id);
   } catch (err) {
     alert(`Failed to load record: ${err.message}`);
   }
+}
+
+document.getElementById("results-body").addEventListener("click", (e) => {
+  const row = e.target.closest("tr[data-id]");
+  if (row) openDetail(row.dataset.id);
+});
+
+document.getElementById("inherited-body").addEventListener("click", (e) => {
+  const row = e.target.closest("tr[data-id]");
+  if (row) openDetail(row.dataset.id);
 });
 
 document.getElementById("close-detail").addEventListener("click", () => {
   document.getElementById("detail-dialog").close();
-  const filters = readFormFilters();
-  delete filters.detail;
-  writeFiltersToURL(filters);
+  writeStateToURL(readFormFilters());
 });
 
 window.addEventListener("popstate", () => {
-  const filters = readFiltersFromURL();
-  populateFormFromFilters(filters);
-  doSearch(filters, filters.cursor || null);
+  const { filters } = readStateFromURL();
+  applyURLState(filters);
+  // Going back may land on a different filter set, so the cached count no longer
+  // applies.
+  totalRecords = null;
+  doSearch(filters);
 });
+
+// Reflects URL-derived state into the form and the window controls.
+function applyURLState(filters) {
+  populateFormFromFilters(filters);
+  document.getElementById("window-size").value = String(windowSize);
+  // A deep link carrying an advanced filter opens the panel, so the constraint
+  // that is shaping the results is never invisible.
+  setAdvancedExpanded(activeAdvancedCount(filters) > 0);
+}
 
 // --- Tabs ---
 
@@ -895,19 +1101,20 @@ document.getElementById("auth-login")?.addEventListener("click", () => {
   refreshTemplateDropdown();
   refreshDatalists();
   document.querySelector('#add-form [name="finished_at"]').value = formatTime(new Date().toISOString());
-  const filters = readFiltersFromURL();
-  populateFormFromFilters(filters);
+
+  const { filters, detail } = readStateFromURL();
+  applyURLState(filters);
   wireUtcPreviews();
 
-  const hasFilters = Object.keys(filters).some(k => k !== "detail" && k !== "cursor");
-  if (hasFilters) {
-    doSearch(filters, filters.cursor || null);
-  }
+  // Always search. The window is a view onto the whole result set, so an empty
+  // filter set is a legitimate query — "everything" — not a prompt to fill the
+  // form in. Only showing results once a filter is set used to leave any link
+  // without one, including a shared deep link, rendering an empty table.
+  await doSearch(filters);
 
-  if (filters.detail) {
+  if (detail) {
     try {
-      const record = await fetchEvidenceById(filters.detail);
-      renderDetail(record);
-    } catch { /* ignore */ }
+      renderDetail(await fetchEvidenceById(detail));
+    } catch { /* record may have been deleted; leave the window as it is */ }
   }
 })();

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -151,6 +151,23 @@ function activeAdvancedCount(filters) {
   return n;
 }
 
+// The result checkboxes live in a closed dropdown most of the time, so the
+// summary has to say what is selected — otherwise an active filter is invisible.
+function refreshResultSummary() {
+  const selected = Array.from(
+    document.querySelectorAll('#result-dropdown [name="result"]:checked')
+  ).map(cb => cb.value);
+
+  const summary = document.getElementById("result-summary");
+  if (selected.length === 0) {
+    summary.textContent = "Result";
+  } else if (selected.length === 1) {
+    summary.textContent = `Result: ${selected[0]}`;
+  } else {
+    summary.textContent = `Result: ${selected.length} selected`;
+  }
+}
+
 function advancedExpanded() {
   return document.getElementById("toggle-advanced").getAttribute("aria-expanded") === "true";
 }
@@ -535,11 +552,33 @@ document.getElementById("clear-filters").addEventListener("click", () => {
   const form = document.getElementById("filter-form");
   form.reset();
   form.querySelectorAll("input[data-utc-preview]").forEach(updateUtcPreview);
+  refreshResultSummary();
   search();
 });
 
 document.getElementById("toggle-advanced").addEventListener("click", () => {
   setAdvancedExpanded(!advancedExpanded());
+});
+
+// --- Result dropdown ---
+
+const resultDropdown = document.getElementById("result-dropdown");
+
+resultDropdown.addEventListener("change", refreshResultSummary);
+
+// <details> has no dismiss behaviour of its own, so closing on an outside click
+// and on Escape has to be wired up.
+document.addEventListener("click", (e) => {
+  if (resultDropdown.open && !resultDropdown.contains(e.target)) {
+    resultDropdown.open = false;
+  }
+});
+
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && resultDropdown.open) {
+    resultDropdown.open = false;
+    resultDropdown.querySelector("summary").focus();
+  }
 });
 
 document.getElementById("first-window").addEventListener("click", () => moveWindow(0));
@@ -615,6 +654,7 @@ window.addEventListener("popstate", () => {
 // Reflects URL-derived state into the form and the window controls.
 function applyURLState(filters) {
   populateFormFromFilters(filters);
+  refreshResultSummary();
   document.getElementById("window-size").value = String(windowSize);
   // A deep link carrying an advanced filter opens the panel, so the constraint
   // that is shaping the results is never invisible.

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -151,6 +151,10 @@ function activeAdvancedCount(filters) {
   return n;
 }
 
+// Initials keep the closed control narrow; the full names go in the tooltip so
+// the abbreviation is never the only way to read the filter.
+const RESULT_INITIALS = { PASS: "P", FAIL: "F", ERROR: "E", SKIPPED: "S" };
+
 // The result checkboxes live in a closed dropdown most of the time, so the
 // summary has to say what is selected — otherwise an active filter is invisible.
 function refreshResultSummary() {
@@ -158,14 +162,14 @@ function refreshResultSummary() {
     document.querySelectorAll('#result-dropdown [name="result"]:checked')
   ).map(cb => cb.value);
 
-  const summary = document.getElementById("result-summary");
+  const label = document.getElementById("result-summary");
   if (selected.length === 0) {
-    summary.textContent = "Result";
-  } else if (selected.length === 1) {
-    summary.textContent = `Result: ${selected[0]}`;
-  } else {
-    summary.textContent = `Result: ${selected.length} selected`;
+    label.textContent = "All Results";
+    label.closest("summary").title = "Filter by result (all results shown)";
+    return;
   }
+  label.textContent = selected.map(v => RESULT_INITIALS[v] || v).join(", ");
+  label.closest("summary").title = selected.join(", ");
 }
 
 function advancedExpanded() {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -107,7 +107,10 @@
                          dropdown. <details> gives the disclosure behaviour for free; the
                          checkboxes stay in the form, so reading the filter is unchanged. -->
                     <details class="fb-dropdown" id="result-dropdown">
-                        <summary id="result-summary" role="button" aria-label="Result filter">Result</summary>
+                        <!-- No role="button": <summary> is already a disclosure control,
+                             and the role both replaces those semantics and drags in
+                             Pico's button colours. -->
+                        <summary><span id="result-summary">All Results</span></summary>
                         <div class="fb-dropdown-menu" role="group" aria-label="Result">
                             <label><input type="checkbox" name="result" value="PASS"> PASS</label>
                             <label><input type="checkbox" name="result" value="FAIL"> FAIL</label>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -96,19 +96,22 @@
         <section id="tab-search" class="tab-content">
             <form id="filter-form">
                 <div id="filter-bar">
-                    <label class="fb-field">Repo
+                    <label class="fb-field fb-field-repo">Repo
                         <input type="text" name="repo" placeholder="org/repo or ~^org/.*" list="repos-list">
                     </label>
-                    <label class="fb-field">Commit
+                    <label class="fb-field fb-field-commit">Commit
                         <input type="text" name="rcs_ref" placeholder="abc123...">
                     </label>
-                    <fieldset class="fb-results">
-                        <legend>Result</legend>
+                    <!-- A div rather than a fieldset: a legend always renders on its own
+                         line, which is the vertical space this bar is trying to save.
+                         role/aria-label keeps the grouping for assistive tech. -->
+                    <div class="fb-results" role="group" aria-label="Result">
+                        <span class="fb-group-label">Result</span>
                         <label><input type="checkbox" name="result" value="PASS"> PASS</label>
                         <label><input type="checkbox" name="result" value="FAIL"> FAIL</label>
                         <label><input type="checkbox" name="result" value="ERROR"> ERROR</label>
                         <label><input type="checkbox" name="result" value="SKIPPED"> SKIPPED</label>
-                    </fieldset>
+                    </div>
                     <div class="fb-actions">
                         <button type="submit">Search</button>
                         <button type="button" class="secondary" id="clear-filters">Clear</button>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -94,80 +94,102 @@
         </section>
 
         <section id="tab-search" class="tab-content">
-        <details id="filter-panel" open>
-            <summary>Filters</summary>
             <form id="filter-form">
-                <small class="regex-hint">Prefix with <code>~</code> for regex, e.g. <code>~^org/.*</code></small>
-                <div class="grid">
-                    <label>Repo <input type="text" name="repo" placeholder="org/repo or ~^org/.*" list="repos-list"></label>
-                    <label>Branch <input type="text" name="branch" placeholder="main or ~^release/.*"></label>
-                    <label>Commit <input type="text" name="rcs_ref" placeholder="abc123..."></label>
-                </div>
-                <div class="grid">
-                    <label>Evidence type <input type="text" name="evidence_type" placeholder="bazel or ~^(bazel|manual)$" list="evidence-types-list"></label>
-                    <label>Source <input type="text" name="source" placeholder="CI URL or user" list="sources-list"></label>
-                    <label>Procedure <input type="text" name="procedure_ref" placeholder="//pkg:target or ~//pkg/.*"></label>
-                </div>
-                <div class="grid">
-                    <fieldset>
+                <div id="filter-bar">
+                    <label class="fb-field">Repo
+                        <input type="text" name="repo" placeholder="org/repo or ~^org/.*" list="repos-list">
+                    </label>
+                    <label class="fb-field">Commit
+                        <input type="text" name="rcs_ref" placeholder="abc123...">
+                    </label>
+                    <fieldset class="fb-results">
                         <legend>Result</legend>
                         <label><input type="checkbox" name="result" value="PASS"> PASS</label>
                         <label><input type="checkbox" name="result" value="FAIL"> FAIL</label>
                         <label><input type="checkbox" name="result" value="ERROR"> ERROR</label>
                         <label><input type="checkbox" name="result" value="SKIPPED"> SKIPPED</label>
                     </fieldset>
-                    <label>After <small>(UTC)</small>
-                        <input type="text" name="finished_after" placeholder="2026-01-01 00:00 (UTC)" data-utc-preview>
-                        <small class="utc-preview" data-preview-for="finished_after"></small>
-                    </label>
-                    <label>Before <small>(UTC)</small>
-                        <input type="text" name="finished_before" placeholder="2026-12-31 23:59 (UTC)" data-utc-preview>
-                        <small class="utc-preview" data-preview-for="finished_before"></small>
-                    </label>
+                    <div class="fb-actions">
+                        <button type="submit">Search</button>
+                        <button type="button" class="secondary" id="clear-filters">Clear</button>
+                        <button type="button" class="secondary outline" id="toggle-advanced" aria-expanded="false" aria-controls="filter-advanced">More filters</button>
+                    </div>
                 </div>
-                <div class="grid">
-                    <label>Tags <input type="text" name="tags" placeholder="ci,nightly or ~^reg.*"></label>
-                    <label>Notes <input type="text" name="notes" placeholder="keyword or ~pattern"></label>
-                    <label>Limit <input type="number" name="limit" min="1" max="1000" placeholder="100"></label>
-                </div>
-                <div class="grid">
-                    <label style="align-self:end"><input type="checkbox" name="include_inherited" checked> Include inherited</label>
-                </div>
-                <div class="filter-actions">
-                    <button type="submit">Search</button>
-                    <button type="button" class="secondary" id="clear-filters">Clear</button>
+
+                <div id="filter-advanced" hidden>
+                    <small class="regex-hint">Prefix with <code>~</code> for regex, e.g. <code>~^org/.*</code></small>
+                    <div class="grid">
+                        <label>Branch <input type="text" name="branch" placeholder="main or ~^release/.*"></label>
+                        <label>Evidence type <input type="text" name="evidence_type" placeholder="bazel or ~^(bazel|manual)$" list="evidence-types-list"></label>
+                        <label>Source <input type="text" name="source" placeholder="CI URL or user" list="sources-list"></label>
+                    </div>
+                    <div class="grid">
+                        <label>Procedure <input type="text" name="procedure_ref" placeholder="//pkg:target or ~//pkg/.*"></label>
+                        <label>After <small>(UTC)</small>
+                            <input type="text" name="finished_after" placeholder="2026-01-01 00:00 (UTC)" data-utc-preview>
+                            <small class="utc-preview" data-preview-for="finished_after"></small>
+                        </label>
+                        <label>Before <small>(UTC)</small>
+                            <input type="text" name="finished_before" placeholder="2026-12-31 23:59 (UTC)" data-utc-preview>
+                            <small class="utc-preview" data-preview-for="finished_before"></small>
+                        </label>
+                    </div>
+                    <div class="grid">
+                        <label>Tags <input type="text" name="tags" placeholder="ci,nightly or ~^reg.*"></label>
+                        <label>Notes <input type="text" name="notes" placeholder="keyword or ~pattern"></label>
+                        <label class="fa-checkbox"><input type="checkbox" name="include_inherited" checked> Include inherited</label>
+                    </div>
                 </div>
             </form>
-        </details>
 
-        <div id="results-summary"></div>
+            <div id="window-bar">
+                <span id="results-summary"></span>
+                <div class="wb-controls">
+                    <label id="window-size-label">Rows
+                        <select id="window-size">
+                            <option value="25">25</option>
+                            <option value="50">50</option>
+                            <option value="100">100</option>
+                            <option value="200">200</option>
+                            <option value="500">500</option>
+                        </select>
+                    </label>
+                    <div id="window-nav">
+                        <button type="button" class="secondary outline" id="first-window" title="First window (Home)" disabled>&laquo;</button>
+                        <button type="button" class="secondary outline" id="prev-page" title="Previous window (PageUp)" disabled>&lsaquo; Prev</button>
+                        <button type="button" class="secondary outline" id="next-page" title="Next window (PageDown)" disabled>Next &rsaquo;</button>
+                        <button type="button" class="secondary outline" id="last-window" title="Last window (End)" disabled>&raquo;</button>
+                    </div>
+                </div>
+            </div>
 
-        <figure>
-            <table id="results-table">
-                <thead>
-                    <tr>
-                        <th>Result</th>
-                        <th>Procedure</th>
-                        <th>Repo</th>
-                        <th>Branch</th>
-                        <th>Commit</th>
-                        <th>Type</th>
-                        <th>Source</th>
-                        <th>Finished</th>
-                        <th>Tags</th>
-                    </tr>
-                </thead>
-                <tbody id="results-body">
-                    <tr><td colspan="9" class="empty-state">Enter filters and click Search</td></tr>
-                </tbody>
-            </table>
-        </figure>
+            <div id="results-window">
+                <table id="results-table">
+                    <thead>
+                        <tr>
+                            <th class="col-result">Result</th>
+                            <th class="col-procedure">Procedure</th>
+                            <th class="col-repo">Repo</th>
+                            <th class="col-branch">Branch</th>
+                            <th class="col-commit">Commit</th>
+                            <th class="col-type">Type</th>
+                            <th class="col-source">Source</th>
+                            <th class="col-finished">Finished</th>
+                            <th class="col-tags">Tags</th>
+                        </tr>
+                    </thead>
+                    <tbody id="results-body">
+                        <tr><td colspan="9" class="empty-state">Loading...</td></tr>
+                    </tbody>
+                </table>
+            </div>
 
-        <div id="pagination">
-            <button id="prev-page" class="secondary" disabled>Previous</button>
-            <button id="next-page" class="secondary" disabled>Next</button>
-        </div>
-
+            <details id="inherited-panel" hidden>
+                <summary><span id="inherited-count">0</span> inherited record(s)</summary>
+                <table id="inherited-table">
+                    <tbody id="inherited-body"></tbody>
+                </table>
+            </details>
         </section>
 
         <dialog id="template-dialog">

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -102,16 +102,19 @@
                     <label class="fb-field fb-field-commit">Commit
                         <input type="text" name="rcs_ref" placeholder="abc123...">
                     </label>
-                    <!-- A div rather than a fieldset: a legend always renders on its own
-                         line, which is the vertical space this bar is trying to save.
-                         role/aria-label keeps the grouping for assistive tech. -->
-                    <div class="fb-results" role="group" aria-label="Result">
-                        <span class="fb-group-label">Result</span>
-                        <label><input type="checkbox" name="result" value="PASS"> PASS</label>
-                        <label><input type="checkbox" name="result" value="FAIL"> FAIL</label>
-                        <label><input type="checkbox" name="result" value="ERROR"> ERROR</label>
-                        <label><input type="checkbox" name="result" value="SKIPPED"> SKIPPED</label>
-                    </div>
+                    <!-- A checkbox dropdown. There is no native HTML control for this:
+                         <select multiple> renders as an always-expanded list box, not a
+                         dropdown. <details> gives the disclosure behaviour for free; the
+                         checkboxes stay in the form, so reading the filter is unchanged. -->
+                    <details class="fb-dropdown" id="result-dropdown">
+                        <summary id="result-summary" role="button" aria-label="Result filter">Result</summary>
+                        <div class="fb-dropdown-menu" role="group" aria-label="Result">
+                            <label><input type="checkbox" name="result" value="PASS"> PASS</label>
+                            <label><input type="checkbox" name="result" value="FAIL"> FAIL</label>
+                            <label><input type="checkbox" name="result" value="ERROR"> ERROR</label>
+                            <label><input type="checkbox" name="result" value="SKIPPED"> SKIPPED</label>
+                        </div>
+                    </details>
                     <div class="fb-actions">
                         <button type="submit">Search</button>
                         <button type="button" class="secondary" id="clear-filters">Clear</button>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1,3 +1,27 @@
+/* Header — Pico gives body>header 1rem of padding top and bottom, and nav li
+   another 1rem each, which costs roughly 80px before any content appears. This
+   is a dense tool, so the chrome is pulled in tight and the space handed to the
+   results window instead. */
+body > header {
+    padding-block: 0.3rem;
+}
+
+body > header nav {
+    font-size: 0.9em;
+}
+
+body > header nav li {
+    padding: 0.1rem 0.4rem;
+}
+
+body > header nav strong {
+    font-size: 0.95em;
+}
+
+body > main {
+    padding-block: 0.4rem 0.5rem;
+}
+
 /* Result badges */
 .badge {
     display: inline-block;
@@ -309,7 +333,7 @@
 /* Results window — a fixed-height viewport onto the current window of records.
    The offset accounts for the header, filter bar and window bar above it. */
 #results-window {
-    max-height: calc(100vh - 15em);
+    max-height: calc(100vh - 9.5em);
     min-height: 16em;
     overflow: auto;
     border: 1px solid var(--pico-muted-border-color);
@@ -703,6 +727,6 @@
     }
 
     #results-window {
-        max-height: calc(100vh - 20em);
+        max-height: calc(100vh - 14em);
     }
 }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -144,7 +144,9 @@
     display: inline-flex;
     align-items: center;
     gap: 0.3em;
-    padding: 0.25em 0.6em;
+    /* An extra em of breathing room a side — the control was cramped against
+       its label and caret. */
+    padding: 0.25em 1.6em;
     margin: 0;
     border: 1px solid var(--pico-muted-border-color);
     border-radius: 4px;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -94,15 +94,145 @@
     font-size: 0.85em;
 }
 
-/* Results */
+/* Collapsed filter bar — the common filters on a single line */
+#filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 0.6em;
+    margin-bottom: 0.4em;
+}
+
+#filter-bar .fb-field {
+    flex: 1 1 14em;
+    min-width: 10em;
+    margin-bottom: 0;
+}
+
+#filter-bar .fb-results {
+    flex: 0 0 auto;
+    margin-bottom: 0.15em;
+}
+
+#filter-bar .fb-actions {
+    display: flex;
+    gap: 0.4em;
+    margin-left: auto;
+}
+
+#filter-bar .fb-actions button {
+    width: auto;
+    padding: 0.3em 1em;
+    font-size: 0.85em;
+    margin-bottom: 0;
+    white-space: nowrap;
+}
+
+/* Advanced filters, revealed by "More filters" */
+#filter-advanced {
+    padding: 0.6em 0.8em;
+    margin-bottom: 0.5em;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 4px;
+}
+
+#filter-advanced .fa-checkbox {
+    align-self: end;
+    display: flex;
+    align-items: center;
+    gap: 0.3em;
+}
+
+/* Window bar — range readout, size selector and window navigation */
+#window-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6em;
+    margin-bottom: 0.4em;
+}
+
 #results-summary {
     font-size: 0.9em;
-    margin-bottom: 0.5em;
     color: var(--pico-muted-color);
+    font-variant-numeric: tabular-nums;
+}
+
+#window-bar .wb-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.6em;
+    margin-left: auto;
+}
+
+#window-size-label {
+    display: flex;
+    align-items: center;
+    gap: 0.35em;
+    font-size: 0.8em;
+    margin-bottom: 0;
+    white-space: nowrap;
+}
+
+#window-size {
+    width: auto;
+    padding: 0.2em 1.6em 0.2em 0.5em;
+    font-size: 0.85em;
+    height: auto;
+    margin-bottom: 0;
+}
+
+#window-nav {
+    display: flex;
+    gap: 0.3em;
+}
+
+#window-nav button {
+    width: auto;
+    padding: 0.25em 0.7em;
+    font-size: 0.8em;
+    margin-bottom: 0;
+    white-space: nowrap;
+}
+
+/* Results window — a fixed-height viewport onto the current window of records */
+#results-window {
+    max-height: calc(100vh - 21em);
+    min-height: 16em;
+    overflow: auto;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 4px;
 }
 
 #results-table {
     font-size: 0.875em;
+    table-layout: fixed;
+    width: 100%;
+    margin: 0;
+}
+
+/* Fixed widths keep columns from reflowing as the window advances. */
+#results-table .col-result    { width: 5.5em; }
+#results-table .col-procedure { width: 20%; }
+#results-table .col-repo      { width: 13%; }
+#results-table .col-branch    { width: 10%; }
+#results-table .col-commit    { width: 7em; }
+#results-table .col-type      { width: 6em; }
+#results-table .col-source    { width: 12%; }
+#results-table .col-finished  { width: 9.5em; }
+
+#results-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--pico-background-color);
+    box-shadow: inset 0 -1px 0 var(--pico-muted-border-color);
+}
+
+#results-table td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 #results-table tbody tr {
@@ -117,6 +247,7 @@
     text-align: center;
     color: var(--pico-muted-color);
     padding: 2em !important;
+    white-space: normal !important;
 }
 
 .commit-ref {
@@ -129,16 +260,21 @@
     font-style: italic;
 }
 
-/* Pagination */
-#pagination {
-    display: flex;
-    gap: 0.5em;
-    justify-content: center;
-    margin-top: 1em;
+/* Inherited records — resolved outside the window, so listed separately */
+#inherited-panel {
+    margin-top: 0.6em;
+    font-size: 0.9em;
 }
 
-#pagination button {
-    width: auto;
+#inherited-panel summary {
+    color: var(--pico-muted-color);
+    font-size: 0.9em;
+}
+
+#inherited-table {
+    font-size: 0.875em;
+    table-layout: fixed;
+    width: 100%;
 }
 
 /* Detail dialog */
@@ -429,8 +565,26 @@
 
 /* Responsive */
 @media (max-width: 768px) {
-    #results-table th:nth-child(n+5),
-    #results-table td:nth-child(n+5) {
+    /* Keyed off column classes rather than position, so the columns that survive
+       stay correct regardless of what else is hidden. */
+    #results-table .col-commit,
+    #results-table .col-type,
+    #results-table .col-source,
+    #results-table .col-finished,
+    #results-table .col-tags {
         display: none;
+    }
+
+    #filter-bar .fb-actions {
+        margin-left: 0;
+        width: 100%;
+    }
+
+    #window-bar .wb-controls {
+        margin-left: 0;
+    }
+
+    #results-window {
+        max-height: calc(100vh - 26em);
     }
 }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -151,13 +151,23 @@
     border: 1px solid var(--pico-muted-border-color);
     border-radius: 4px;
     background: none;
-    color: var(--pico-color);
+    /* `inherit`, not var(--pico-color): that variable is reassigned by several
+       Pico component rules, and picking up the wrong one renders the label in a
+       colour meant for a filled background. */
+    color: inherit;
     font-size: 1em;
     font-weight: normal;
     line-height: inherit;
     white-space: nowrap;
     cursor: pointer;
     list-style: none;
+}
+
+/* Pinned width, so selecting results doesn't resize the control and shove the
+   buttons beside it around. Fits the longest label, "All Results". */
+#filter-bar .fb-dropdown > summary > span {
+    display: inline-block;
+    min-width: 11ch;
 }
 
 /* Replace both marker implementations with one caret we control. */

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -309,12 +309,20 @@ body > main {
     white-space: nowrap;
 }
 
+/* Pico paints the chevron as a 1rem background-image inset 0.75rem from the
+   right, sized in rem while this control is a fraction of a rem — so it landed
+   on top of the digits. The value is self-explanatory, so drop the arrow and
+   reclaim its padding; `padding-inline-end` is set explicitly because Pico
+   reserves the arrow's space with the logical property. */
 #window-size {
     width: auto;
-    padding: 0.2em 1.6em 0.2em 0.5em;
+    padding: 0.2em 0.5em;
+    padding-inline-end: 0.5em;
+    background-image: none;
     font-size: 0.85em;
     height: auto;
     margin-bottom: 0;
+    text-align: center;
 }
 
 #window-nav {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -111,6 +111,12 @@ body > main {
    Labels sit beside their inputs rather than above, which is what keeps the bar
    one line tall instead of two. */
 #filter-bar {
+    /* One height for every control in the bar. Pico sizes inputs with
+       `calc(1rem * line-height + ...)`, where the 1rem is absolute and so ignores
+       this bar's smaller font — that made the inputs noticeably taller than the
+       dropdown, which carries no such rule. Pinning both here keeps them level. */
+    --fb-control-height: 35px;
+
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -138,13 +144,23 @@ body > main {
    identifiers of bounded length. Longer values (full hashes, or `~` regex
    filters — which is why there is no maxlength) scroll.
 
-   content-box matters here: under Pico's global border-box, a 40ch width would
-   be consumed by the padding and border, leaving about 38 characters visible. */
+   The padding and border are added back explicitly, because under Pico's global
+   border-box a plain 40ch would be consumed by them and leave about 38
+   characters visible. Doing it this way rather than with content-box keeps
+   box-sizing consistent, so the shared height below means the height it says. */
 #filter-bar .fb-field-repo input,
 #filter-bar .fb-field-commit input {
     flex: 0 0 auto;
-    box-sizing: content-box;
-    width: 40ch;
+    width: calc(40ch
+        + 2 * var(--pico-form-element-spacing-horizontal)
+        + 2 * var(--pico-border-width));
+}
+
+/* Every control in the bar shares one height, so they sit on a common baseline
+   regardless of how each one would otherwise size itself. */
+#filter-bar .fb-field input,
+#filter-bar .fb-dropdown > summary {
+    height: var(--fb-control-height);
 }
 
 #filter-bar .fb-field-commit input {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -108,14 +108,18 @@
     margin-bottom: 0;
 }
 
-/* Both inputs are sized in `ch`, which is the width of the element's own "0"
-   glyph — so 40ch of the monospace commit field is exactly a 40-character hash.
-   Repo is proportional, so its 40ch renders a little narrower. Neither grows:
-   both hold identifiers of bounded length. Longer values (full hashes, or `~`
-   regex filters — which is why there is no maxlength) scroll. */
+/* Both inputs are sized in `ch`, the width of the element's own "0" glyph, so
+   the monospace commit field holds exactly a 40-character hash. Repo is
+   proportional, so its 40ch renders a little narrower. Neither grows: both hold
+   identifiers of bounded length. Longer values (full hashes, or `~` regex
+   filters — which is why there is no maxlength) scroll.
+
+   content-box matters here: under Pico's global border-box, a 40ch width would
+   be consumed by the padding and border, leaving about 38 characters visible. */
 #filter-bar .fb-field-repo input,
 #filter-bar .fb-field-commit input {
     flex: 0 0 auto;
+    box-sizing: content-box;
     width: 40ch;
 }
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -108,39 +108,96 @@
     margin-bottom: 0;
 }
 
-/* Repo is the only field that benefits from extra room, so it takes the slack. */
-#filter-bar .fb-field-repo {
-    flex: 1 1 16em;
-    min-width: 9em;
+/* Both inputs are sized in `ch`, which is the width of the element's own "0"
+   glyph — so 40ch of the monospace commit field is exactly a 40-character hash.
+   Repo is proportional, so its 40ch renders a little narrower. Neither grows:
+   both hold identifiers of bounded length. Longer values (full hashes, or `~`
+   regex filters — which is why there is no maxlength) scroll. */
+#filter-bar .fb-field-repo input,
+#filter-bar .fb-field-commit input {
+    flex: 0 0 auto;
+    width: 40ch;
 }
 
-/* A revision hash has a bounded length, so this field never needs to grow.
-   Sized for a comfortable prefix; full-length hashes and `~` regexes still fit,
-   they just scroll — hence no maxlength. */
 #filter-bar .fb-field-commit input {
-    flex: 0 0 13em;
-    width: 13em;
     font-family: monospace;
 }
 
-#filter-bar .fb-results {
-    display: flex;
-    align-items: center;
-    gap: 0.5em;
-    flex: 0 0 auto;
-}
-
-#filter-bar .fb-results label {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25em;
-    margin: 0;
-    white-space: nowrap;
-}
-
-#filter-bar .fb-group-label,
 #filter-bar .fb-field {
     color: var(--pico-muted-color);
+}
+
+/* Result dropdown */
+#filter-bar .fb-dropdown {
+    position: relative;
+    flex: 0 0 auto;
+    margin: 0;
+    border: none;
+    padding: 0;
+}
+
+#filter-bar .fb-dropdown > summary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+    padding: 0.25em 0.6em;
+    margin: 0;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 4px;
+    background: none;
+    color: var(--pico-color);
+    font-size: 1em;
+    font-weight: normal;
+    line-height: inherit;
+    white-space: nowrap;
+    cursor: pointer;
+    list-style: none;
+}
+
+/* Replace both marker implementations with one caret we control. */
+#filter-bar .fb-dropdown > summary::-webkit-details-marker { display: none; }
+#filter-bar .fb-dropdown > summary::marker { content: ""; }
+
+#filter-bar .fb-dropdown > summary::after {
+    content: "";
+    border: 0.3em solid transparent;
+    border-top-color: currentColor;
+    margin-top: 0.3em;
+    transform: none;
+    width: 0;
+    height: 0;
+    background: none;
+}
+
+#filter-bar .fb-dropdown[open] > summary::after {
+    margin-top: -0.3em;
+    border-top-color: transparent;
+    border-bottom-color: currentColor;
+}
+
+#filter-bar .fb-dropdown-menu {
+    position: absolute;
+    z-index: 20;
+    top: calc(100% + 0.25em);
+    left: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3em;
+    min-width: 100%;
+    padding: 0.5em 0.7em;
+    background: var(--pico-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+
+#filter-bar .fb-dropdown-menu label {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    margin: 0;
+    white-space: nowrap;
+    cursor: pointer;
 }
 
 #filter-bar .fb-actions {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -30,19 +30,21 @@
     font-size: 0.95em;
 }
 
-/* Compact forms */
-#filter-form label,
+/* Compact forms.
+   The filter bar sizes itself (see #filter-bar) — applying the 0.8em here too
+   would compound against it, so only the advanced panel is covered. */
+#filter-advanced label,
 #add-form label {
     font-size: 0.8em;
     margin-bottom: 0;
 }
 
-#filter-form input,
-#filter-form select,
+#filter-advanced input,
+#filter-advanced select,
 #add-form input,
 #add-form select,
 #add-form textarea {
-    padding: 0.3em 0.5em;
+    padding: 0.25em 0.5em;
     font-size: 0.85em;
     height: auto;
 }
@@ -53,27 +55,6 @@
     margin-bottom: 0.3em;
 }
 
-#filter-form fieldset {
-    border: none;
-    padding: 0;
-    margin: 0;
-}
-
-#filter-form fieldset legend {
-    font-size: 0.8em;
-    font-weight: 600;
-    margin-bottom: 0.15em;
-}
-
-#filter-form fieldset label {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3em;
-    margin-right: 0.6em;
-    font-size: 0.8em;
-}
-
-#filter-form fieldset input[type="checkbox"],
 #filter-form input[type="checkbox"] {
     -webkit-appearance: checkbox;
     appearance: checkbox;
@@ -94,46 +75,103 @@
     font-size: 0.85em;
 }
 
-/* Collapsed filter bar — the common filters on a single line */
+/* Compress Pico's form rhythm for the whole search view. Its defaults are sized
+   for prose-width forms; this view is a dense data table. */
+#tab-search {
+    --pico-form-element-spacing-vertical: 0.3em;
+    --pico-form-element-spacing-horizontal: 0.5em;
+    --pico-spacing: 0.5rem;
+}
+
+/* Collapsed filter bar — the common filters on a single line.
+   Labels sit beside their inputs rather than above, which is what keeps the bar
+   one line tall instead of two. */
 #filter-bar {
     display: flex;
     flex-wrap: wrap;
-    align-items: flex-end;
-    gap: 0.6em;
-    margin-bottom: 0.4em;
+    align-items: center;
+    gap: 0.3em 0.7em;
+    margin-bottom: 0.35em;
+    font-size: 0.8em;
 }
 
 #filter-bar .fb-field {
-    flex: 1 1 14em;
-    min-width: 10em;
+    display: flex;
+    align-items: center;
+    gap: 0.35em;
+    margin-bottom: 0;
+    white-space: nowrap;
+}
+
+#filter-bar .fb-field input {
+    font-size: 1em;
     margin-bottom: 0;
 }
 
+/* Repo is the only field that benefits from extra room, so it takes the slack. */
+#filter-bar .fb-field-repo {
+    flex: 1 1 16em;
+    min-width: 9em;
+}
+
+/* A revision hash has a bounded length, so this field never needs to grow.
+   Sized for a comfortable prefix; full-length hashes and `~` regexes still fit,
+   they just scroll — hence no maxlength. */
+#filter-bar .fb-field-commit input {
+    flex: 0 0 13em;
+    width: 13em;
+    font-family: monospace;
+}
+
 #filter-bar .fb-results {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
     flex: 0 0 auto;
-    margin-bottom: 0.15em;
+}
+
+#filter-bar .fb-results label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+    margin: 0;
+    white-space: nowrap;
+}
+
+#filter-bar .fb-group-label,
+#filter-bar .fb-field {
+    color: var(--pico-muted-color);
 }
 
 #filter-bar .fb-actions {
     display: flex;
-    gap: 0.4em;
+    gap: 0.35em;
     margin-left: auto;
 }
 
 #filter-bar .fb-actions button {
     width: auto;
-    padding: 0.3em 1em;
-    font-size: 0.85em;
+    padding: 0.25em 0.9em;
+    font-size: 1em;
     margin-bottom: 0;
     white-space: nowrap;
 }
 
 /* Advanced filters, revealed by "More filters" */
 #filter-advanced {
-    padding: 0.6em 0.8em;
-    margin-bottom: 0.5em;
+    padding: 0.45em 0.6em 0.15em;
+    margin-bottom: 0.4em;
     border: 1px solid var(--pico-muted-border-color);
     border-radius: 4px;
+}
+
+#filter-advanced .grid {
+    gap: 0.3em 0.6em;
+    margin-bottom: 0.25em;
+}
+
+#filter-advanced label {
+    margin-bottom: 0;
 }
 
 #filter-advanced .fa-checkbox {
@@ -148,8 +186,8 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.6em;
-    margin-bottom: 0.4em;
+    gap: 0.4em;
+    margin-bottom: 0.3em;
 }
 
 #results-summary {
@@ -195,9 +233,10 @@
     white-space: nowrap;
 }
 
-/* Results window — a fixed-height viewport onto the current window of records */
+/* Results window — a fixed-height viewport onto the current window of records.
+   The offset accounts for the header, filter bar and window bar above it. */
 #results-window {
-    max-height: calc(100vh - 21em);
+    max-height: calc(100vh - 15em);
     min-height: 16em;
     overflow: auto;
     border: 1px solid var(--pico-muted-border-color);
@@ -205,10 +244,16 @@
 }
 
 #results-table {
-    font-size: 0.875em;
+    font-size: 0.8em;
     table-layout: fixed;
     width: 100%;
     margin: 0;
+}
+
+/* Dense rows: this is a data table, not prose. */
+#results-table th,
+#results-table td {
+    padding: 0.25em 0.5em;
 }
 
 /* Fixed widths keep columns from reflowing as the window advances. */
@@ -585,6 +630,6 @@
     }
 
     #results-window {
-        max-height: calc(100vh - 26em);
+        max-height: calc(100vh - 20em);
     }
 }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -716,6 +716,13 @@ body > main {
     cursor: default;
 }
 
+/* Only the After/Before labels carry a preview, so reserving a line for an empty
+   one made the middle row of the advanced grid taller than its neighbours. It
+   takes no space until it has something to report. */
+.utc-preview:empty {
+    display: none;
+}
+
 .utc-preview {
     display: block;
     min-height: 1.2em;


### PR DESCRIPTION
Stage 2 of #43. Builds on the offset pagination from #59.

## What changed

**Collapsible filter bar.** Repo, Commit and Result stay on one line; the other nine fields hide behind `More filters`, which carries a count of the advanced filters currently applied — a collapsed panel never hides a constraint that is shaping the results. A deep link carrying an advanced filter opens the panel for the same reason.

**Windowed results.** A fixed-height container with a sticky header and exactly one window of rows in the DOM. Size is chosen from the status bar (25–500) and persisted in `localStorage`. Navigation is First/Prev/Next/Last plus `PageUp`/`PageDown`/`Home`/`End`.

**Range readout.** `1,002–1,052 of 8,431 records`, which is what the issue asked for and what cursor pagination could not express.

**Inherited records** render in their own panel below the window, since they are resolved outside it and would otherwise distort the range.

## Fixes a reported bug

Copying the URL of page 2 and opening it rendered an empty table. Two causes, both fixed:

- The URL carried only `?cursor=…`, and the init guard explicitly excluded `cursor` from what counts as a filter, so no search ran.
- Even had it run, a cursor cannot reconstruct that view: it is an opaque position marker, so there was no range to display, `Previous` was dead (empty `cursorStack`), and the API returns no `total` for cursor requests.

The URL now describes a window — `?repo=…&offset=1000&limit=50` restores the view exactly. A `cursor=` from an older link is ignored and opens the first window. More broadly, the view **always searches on load**: an empty filter set is a legitimate query ("everything"), not a prompt to fill in the form, so no link can land on a blank table.

## Jumping to the end no longer costs seconds

`OFFSET` makes Postgres walk every skipped row. The client now approaches a window from whichever end is closer and reverses the rows. Measured against 4,000,009 records:

| window | direct read | far-end read |
|---|---|---|
| last (`End`) | 13.1s | **0.001s** |
| offset 3,000,000 | 9.8s | 3.3s |

Both paths return byte-identical record IDs.

This requires descending order to be the exact reverse of ascending, so **the store's `id` tie-break now follows the sort direction** (`internal/store/evidence.go`). That is the only backend change here. `TestReversedWindowMatchesDirectWindow` covers it, seeding records through the batch endpoint so they share an `ingested_at` — every record in a batch does, since `now()` is the transaction timestamp — which is exactly the case the old fixed `id ASC` tie-break got wrong.

## Testing

`go vet ./...`, `go test ./internal/... ./tests/`, and `bazel test //...` (8/8) all pass. Request paths, timings and the served markup were verified against a local 4M-record database.

**Not visually verified** — no browser tooling was available in the session that wrote this. Worth an eyeball before merge: sticky header alignment under `table-layout: fixed`, and whether the `calc(100vh - 21em)` window height sits well on a smaller screen.

Stage 3 (sortable column headers, column chooser + density, saved filter presets) is still open; the sort state is already plumbed through the URL and fetch layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)