### PR TITLE
Add per-test analytics metrics and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Base URL: `/api/v1`
 | `GET` | `/api/v1/evidence/{id}` | Get record by ID |
 | `POST` | `/api/v1/inheritance` | Create an inheritance declaration |
 | `GET` | `/api/v1/inheritance` | List inheritance declarations |
+| `GET` | `/api/v1/analytics/summary` | Headline counts for a filter window |
+| `GET` | `/api/v1/analytics/tests` | Per-test reliability metrics (see [Analytics](#analytics)) |
 | `GET` | `/healthz` | Health check |
 
 ### Creating evidence
@@ -360,6 +362,59 @@ curl "http://localhost:8000/api/v1/evidence?notes=~device.*XYZ"
 **Supported fields:** `repo`, `branch`, `rcs_ref`, `evidence_type`, `source`, `procedure_ref`, `tags`, `notes`.
 
 The regex engine is [PostgreSQL POSIX regular expressions](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP) (the `~` operator). This supports the POSIX Extended Regular Expression syntax including character classes (`[a-z]`, `[[:digit:]]`), alternation (`a|b`), quantifiers (`*`, `+`, `?`, `{n,m}`), and anchors (`^`, `$`). Matching is case-sensitive.
+
+## Analytics
+
+`/api/v1/analytics/tests` collapses the evidence into one row per test — identified by `(repo, procedure_ref)` — so a suite can be judged rather than read record by record. It accepts every filter the list endpoint does, including the `~` regex and `*` prefix forms.
+
+```bash
+# Tests that never fail, best-evidenced first
+curl "http://localhost:8000/api/v1/analytics/tests?repo=org/repo&sort=pass_rate_lower&order=desc"
+
+# Chronically broken tests
+curl "http://localhost:8000/api/v1/analytics/tests?repo=org/repo&sort=fail_rate&order=desc"
+
+# Tests losing the most runs to infrastructure
+curl "http://localhost:8000/api/v1/analytics/tests?repo=org/repo&sort=error_rate&order=desc"
+
+# Flakiest tests in the last 30 days
+curl "http://localhost:8000/api/v1/analytics/tests?repo=org/repo&finished_after=2026-06-27&sort=flip_rate&order=desc"
+```
+
+### Metrics
+
+| Field | Meaning |
+|-------|---------|
+| `fail_rate` | `fail / (pass + fail)`. `ERROR` and `SKIPPED` are excluded — an infrastructure crash says nothing about whether the test is broken. |
+| `error_rate` | `error / (pass + fail + error)`. The infrastructure-trouble ranking. |
+| `flip_rate` | Share of consecutive verdicts that changed outcome. A permanently broken test has `fail_rate` 1.0 and `flip_rate` 0; a flaky one has a middling fail rate and a high flip rate. |
+| `flaky_commits` | Commits where the test both passed and failed. Same code, different outcome. |
+| `pass_rate_lower` | Wilson 95% lower bound on the pass rate. Ranks a clean 500-run record above a clean 8-run one, where the raw rate ties them at 1.0. |
+
+### Labels
+
+Each test carries a list of labels, not one category — a test can be both flaky and infrastructure-heavy.
+
+| Label | Rule |
+|-------|------|
+| `stable` | At least `min_runs` verdicts, no failures and no errors |
+| `always_failing` | At least `min_runs` verdicts and `fail_rate` ≥ `always_failing_rate` |
+| `flaky` | Any `flaky_commits`, or `flip_rate` ≥ the `flip_rate` threshold |
+| `infra_heavy` | At least `min_errors` errors and `error_rate` ≥ the `error_rate` threshold |
+| `sparse` | Fewer than `min_runs` verdicts — too little history to judge |
+
+Thresholds are query parameters (`min_runs`, `always_failing_rate`, `flip_rate`, `error_rate`, `min_errors`), because what counts as "almost always failing" is a judgement about a particular suite. The defaults are echoed back in every response.
+
+### Other parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `sort` | `procedure_ref` | `fail_rate`, `error_rate`, `flip_rate`, `pass_rate_lower`, `runs`, `pass`, `fail`, `error`, `flaky_commits`, `last_seen`, … |
+| `order` | `asc` | `asc` or `desc` |
+| `limit`, `offset` | page size config | Windows the sorted set; `total` always describes the whole set |
+| `group_by` | *(none)* | `evidence_type` splits a procedure into one row per harness |
+
+A query matching more than 50,000 distinct tests returns `422` rather than truncating, since a truncated set yields confident-looking numbers computed from part of the data.
 
 ## Development
 

--- a/docs/analytics-plan.md
+++ b/docs/analytics-plan.md
@@ -53,7 +53,7 @@ Counts come straight from `count(*) FILTER (WHERE result = …)`.
 - **`pass_rate_lower`** = Wilson score lower bound (95%) on the pass rate. Used to rank "never fails" so that 500/500 outranks 8/8 instead of tying at 1.0.
 - `first_seen`, `last_seen`, `last_pass_at`, `last_fail_at`, `last_result`
 
-Everything except `pass_rate_lower` is one SQL pass; the Wilson bound is a pure Go function over the counts.
+The division of labour: **SQL counts, Go divides.** One SQL pass produces the raw tallies — including `flips` and `transitions` as separate counts from the `lag()` scan — and every rate, bound, and label is then a pure function in `internal/analytics`. This keeps each metric defined in exactly one place and unit-testable without a database, and it is why sorting happens in Go too: ordering by `fail_rate` in SQL would mean writing that definition a second time, in a second language, where the two could drift apart.
 
 ### Labels
 
@@ -91,16 +91,23 @@ Guardrails: hard caps on rows scanned (200k) and tests considered (2,000, by fai
 
 Aggregation in Postgres, correlation in Go, nothing precomputed in phase 1. The per-test query is a single grouped scan over a time window; the cluster query returns a projection of failing rows only. If measurement shows this is too slow at real volumes, the escape hatch is a nightly rollup table keyed by `(repo, procedure_ref, day)` — deferred until there is a number that justifies it.
 
-One new index, to be confirmed by `EXPLAIN ANALYZE` against seeded data before being committed:
+One new index. **Measured** on 1,000,000 seeded rows (12 repos, 88 procedures, 70k rows matching a 90-day window):
 
-```sql
--- migrations/000004_add_analytics_index.up.sql
-CREATE INDEX idx_evidence_analytics
-    ON evidence (repo, finished_at DESC)
-    INCLUDE (procedure_ref, result, rcs_ref, branch, evidence_type);
-```
+| index | time | size |
+|---|---|---|
+| *(none — baseline)* | 450 ms | — |
+| `(repo, finished_at DESC) INCLUDE (…)` | 328 ms | 155 MB |
+| `(repo, procedure_ref, finished_at DESC)` | 450 ms | 79 MB — planner ignores it |
+| **`(repo, procedure_ref, finished_at DESC) INCLUDE (result, rcs_ref, id)`** | **197 ms** | 149 MB |
 
-Today `repo` and `finished_at` are separate single-column indexes, so the planner bitmap-ANDs them and then hits the heap for every row. The composite with `INCLUDE` allows an index-only scan for the whole aggregation. The cost is index size — measure both before merging.
+Two things came out of the measurement that the original guess had backwards:
+
+1. **Leading with the group key beats leading with the time column.** The proposal assumed `(repo, finished_at)` was the right shape. Ordering by `(repo, procedure_ref, finished_at)` supplies the `GROUP BY` and the `DISTINCT ON` ordering directly, which removes an external merge sort that was spilling ~6 MB to disk.
+2. **The `INCLUDE` is not optional.** Without it the planner ignores the index entirely and falls back to the bitmap scan — same 450 ms, so the lean 79 MB variant buys nothing. With it the scan is index-only (`Heap Fetches: 0`).
+
+The `filtered` CTE therefore projects only the group columns, so `evidence_type` is selected only when a caller actually groups by it; selecting it unconditionally would force a heap fetch per row for everyone else.
+
+The cost is index size: roughly half the table's own size again (149 MB against a 275 MB table). Deployments that do not use the analytics endpoints can drop it and the queries still work, at the 450 ms figure above.
 
 ## API
 
@@ -119,15 +126,19 @@ Extra parameters: `min_runs`, `group_by`, `run_key`, `sort`, `order`, `limit`, `
 
 ```json
 {
-  "window": { "from": "2026-06-01T00:00:00Z", "to": "2026-07-26T00:00:00Z", "runs": 1240 },
+  "window": { "from": "2026-06-01T00:00:00Z", "to": "2026-07-26T00:00:00Z", "runs": 1240, "tests": 843 },
+  "thresholds": { "min_runs": 10, "always_failing_rate": 0.9, "flip_rate": 0.2, "error_rate": 0.1, "min_errors": 3 },
   "tests": [
     {
       "repo": "org/repo",
       "procedure_ref": "//pkg:integration_test",
-      "runs": 210, "pass": 168, "fail": 20, "error": 22, "skipped": 0,
+      "counts": {
+        "pass": 168, "fail": 20, "error": 22, "skipped": 0,
+        "flips": 26, "transitions": 187, "flaky_commits": 3
+      },
+      "runs": 210,
       "verdict_runs": 188,
-      "fail_rate": 0.106, "error_rate": 0.117, "flip_rate": 0.14,
-      "flaky_commits": 3,
+      "fail_rate": 0.106, "error_rate": 0.117, "flip_rate": 0.139,
       "pass_rate_lower": 0.837,
       "last_result": "PASS",
       "last_fail_at": "2026-07-24T09:12:00Z",
@@ -137,6 +148,12 @@ Extra parameters: `min_runs`, `group_by`, `run_key`, `sort`, `order`, `limit`, `
   "total": 843
 }
 ```
+
+The raw counts are nested under `counts` rather than flattened alongside the
+derived rates. Flattening would put a `runs` field next to a `Runs()` method on
+the same Go struct, where the field silently shadows the method — a trap worth
+avoiding for the sake of a slightly shorter payload. `flips` and `transitions`
+are reported so a caller can check `flip_rate` rather than having to trust it.
 
 `GET /analytics/clusters`:
 
@@ -168,6 +185,10 @@ A fourth nav tab, `Analytics`, with three sub-views sharing the existing filter 
 - **Clusters** — the cluster list, and the minimal covering set as a table with a cumulative-coverage bar.
 
 **Charts**: the page needs a sparkline and a stacked bar, nothing more. I recommend hand-rolled inline SVG (~100 lines in a small `chart.js` module) over pulling a charting library from a CDN. `index.html` does already load Pico from jsdelivr, so a CDN dependency is not unprecedented — but a full chart library is a large surface for two chart types, and inline SVG keeps the page working offline and in air-gapped deployments. Flagged as the one call worth your input before I start on phase 3.
+
+## Status
+
+Phase 0 and phase 1 are implemented. Phases 2–4 are still as proposed below.
 
 ## Implementation Phases
 

--- a/internal/analytics/BUILD.bazel
+++ b/internal/analytics/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "analytics",
+    srcs = [
+        "metrics.go",
+        "stats.go",
+    ],
+    importpath = "github.com/nesono/evidence-store/internal/analytics",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "analytics_test",
+    srcs = [
+        "metrics_test.go",
+        "stats_test.go",
+    ],
+    embed = [":analytics"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/internal/analytics/metrics.go
+++ b/internal/analytics/metrics.go
@@ -1,0 +1,166 @@
+// Package analytics derives reliability metrics from evidence verdict counts.
+//
+// The counting and the ordered scan happen in SQL, which is what SQL is good at.
+// Everything that turns those counts into a rate, a bound, or a judgement lives
+// here as a pure function, so the definitions are unit-testable without a
+// database and there is exactly one place where each of them is written down.
+package analytics
+
+import "math"
+
+// Counts is the verdict tally for one test over a query window, as returned by
+// the store's aggregation.
+type Counts struct {
+	Pass    int `json:"pass"`
+	Fail    int `json:"fail"`
+	Error   int `json:"error"`
+	Skipped int `json:"skipped"`
+
+	// Flips is the number of consecutive verdict pairs that changed outcome, and
+	// Transitions the number of such pairs compared. Both come from an ordered
+	// scan in SQL; the ratio is FlipRate.
+	Flips       int `json:"flips"`
+	Transitions int `json:"transitions"`
+
+	// FlakyCommits is the number of distinct rcs_refs at which this test both
+	// passed and failed.
+	FlakyCommits int `json:"flaky_commits"`
+}
+
+// Runs is every record for the test, whatever the outcome.
+func (c Counts) Runs() int { return c.Pass + c.Fail + c.Error + c.Skipped }
+
+// VerdictRuns is the runs that produced an actual statement about the test:
+// it either passed or it failed.
+func (c Counts) VerdictRuns() int { return c.Pass + c.Fail }
+
+// FailRate is the share of verdicts that were failures. ERROR and SKIPPED are
+// excluded deliberately — an infrastructure crash says nothing about whether the
+// test is broken, and folding it in makes flaky infrastructure look like a
+// failing test.
+func (c Counts) FailRate() float64 {
+	return ratio(c.Fail, c.VerdictRuns())
+}
+
+// ErrorRate is the share of executed runs lost to infrastructure. SKIPPED is
+// excluded so that a mostly-skipped test does not dilute the signal.
+func (c Counts) ErrorRate() float64 {
+	return ratio(c.Error, c.Pass+c.Fail+c.Error)
+}
+
+// FlipRate is the share of consecutive verdict pairs that changed outcome. It is
+// the separator the fail rate cannot provide: a permanently broken test has a
+// fail rate of 1.0 and a flip rate of 0, while a flaky one has a middling fail
+// rate and a high flip rate.
+func (c Counts) FlipRate() float64 {
+	return ratio(c.Flips, c.Transitions)
+}
+
+// PassRateLower is the Wilson lower bound on the pass rate, used to rank tests
+// by how well evidenced their clean record is. Ranking on the raw pass rate
+// ties 8/8 with 500/500; this does not.
+func (c Counts) PassRateLower() float64 {
+	return WilsonLower(c.Pass, c.VerdictRuns())
+}
+
+// z95 is the standard normal quantile for a 95% two-sided interval.
+const z95 = 1.959963984540054
+
+// WilsonLower returns the lower bound of the Wilson score interval for a
+// proportion of successes out of total, at 95% confidence.
+//
+// It returns 0 for an empty or nonsensical sample rather than a NaN, because the
+// result is used as a sort key and a NaN there silently corrupts the ordering.
+func WilsonLower(successes, total int) float64 {
+	if total <= 0 || successes < 0 {
+		return 0
+	}
+	n := float64(total)
+	p := float64(successes) / n
+
+	denominator := 1 + z95*z95/n
+	center := p + z95*z95/(2*n)
+	margin := z95 * math.Sqrt(p*(1-p)/n+z95*z95/(4*n*n))
+
+	return clamp01((center - margin) / denominator)
+}
+
+// Labels a test can carry. A test gets a list rather than a single category,
+// because a test can legitimately be both flaky and infrastructure-heavy and
+// picking one to show would hide the other.
+const (
+	LabelStable        = "stable"
+	LabelAlwaysFailing = "always_failing"
+	LabelFlaky         = "flaky"
+	LabelInfraHeavy    = "infra_heavy"
+	LabelSparse        = "sparse"
+)
+
+// Thresholds tune the labelling. They are request parameters rather than
+// constants — what counts as "almost always failing" is a judgement about a
+// particular test suite, not a universal truth.
+type Thresholds struct {
+	// MinRuns is the number of verdicts below which a test is called sparse and
+	// no claim is made about its reliability.
+	MinRuns int `json:"min_runs"`
+	// AlwaysFailingRate is the fail rate at or above which a test is considered
+	// chronically broken.
+	AlwaysFailingRate float64 `json:"always_failing_rate"`
+	// FlipRate is the flip rate at or above which a test is considered flaky.
+	FlipRate float64 `json:"flip_rate"`
+	// ErrorRate is the error rate at or above which a test is considered
+	// infrastructure-heavy, subject to MinErrors.
+	ErrorRate float64 `json:"error_rate"`
+	// MinErrors guards ErrorRate against tiny samples, where a single failed
+	// container start would otherwise be a 33% error rate.
+	MinErrors int `json:"min_errors"`
+}
+
+func DefaultThresholds() Thresholds {
+	return Thresholds{
+		MinRuns:           10,
+		AlwaysFailingRate: 0.9,
+		FlipRate:          0.2,
+		ErrorRate:         0.1,
+		MinErrors:         3,
+	}
+}
+
+// Labels classifies a test. Thresholds are inclusive, and the returned slice is
+// always non-nil so it renders as [] rather than null.
+func (t Thresholds) Labels(c Counts) []string {
+	labels := []string{}
+	enough := c.VerdictRuns() >= t.MinRuns
+
+	switch {
+	case !enough:
+		labels = append(labels, LabelSparse)
+	case c.Fail == 0 && c.Error == 0:
+		labels = append(labels, LabelStable)
+	case c.FailRate() >= t.AlwaysFailingRate:
+		labels = append(labels, LabelAlwaysFailing)
+	}
+
+	if c.FlakyCommits > 0 || c.FlipRate() >= t.FlipRate {
+		labels = append(labels, LabelFlaky)
+	}
+	if c.Error >= t.MinErrors && c.ErrorRate() >= t.ErrorRate {
+		labels = append(labels, LabelInfraHeavy)
+	}
+
+	return labels
+}
+
+func ratio(numerator, denominator int) float64 {
+	if denominator <= 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}
+
+func clamp01(v float64) float64 {
+	if math.IsNaN(v) {
+		return 0
+	}
+	return math.Max(0, math.Min(1, v))
+}

--- a/internal/analytics/metrics_test.go
+++ b/internal/analytics/metrics_test.go
@@ -1,0 +1,186 @@
+package analytics
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func assertClose(t *testing.T, want, got float64) {
+	t.Helper()
+	assert.InDelta(t, want, got, 1e-6)
+}
+
+func TestCountsRuns(t *testing.T) {
+	c := Counts{Pass: 10, Fail: 3, Error: 2, Skipped: 1}
+	assert.Equal(t, 16, c.Runs())
+	assert.Equal(t, 13, c.VerdictRuns())
+}
+
+// ERROR and SKIPPED are excluded from the fail rate: an infrastructure crash is
+// not a statement about whether the test itself is broken.
+func TestFailRateExcludesErrorAndSkipped(t *testing.T) {
+	c := Counts{Pass: 8, Fail: 2, Error: 90, Skipped: 50}
+	assertClose(t, 0.2, c.FailRate())
+}
+
+func TestFailRateNoVerdicts(t *testing.T) {
+	assertClose(t, 0, Counts{Error: 5, Skipped: 3}.FailRate())
+	assertClose(t, 0, Counts{}.FailRate())
+}
+
+// SKIPPED is excluded from the error rate too, so a mostly-skipped test does not
+// dilute the infrastructure signal.
+func TestErrorRate(t *testing.T) {
+	c := Counts{Pass: 7, Fail: 1, Error: 2, Skipped: 40}
+	assertClose(t, 0.2, c.ErrorRate())
+	assertClose(t, 0, Counts{Skipped: 9}.ErrorRate())
+}
+
+func TestFlipRate(t *testing.T) {
+	// 9 comparable pairs, 3 of which changed verdict.
+	assertClose(t, 1.0/3.0, Counts{Flips: 3, Transitions: 9}.FlipRate())
+	assertClose(t, 0, Counts{Flips: 0, Transitions: 0}.FlipRate())
+}
+
+// The property that makes the Wilson bound worth using: on the raw rate a
+// 10-run and a 500-run clean record tie at a perfect score, and the bound
+// breaks that tie in favour of the one backed by more evidence.
+func TestPassRateLowerRewardsEvidence(t *testing.T) {
+	short := Counts{Pass: 10}
+	long := Counts{Pass: 500}
+
+	assertClose(t, 0, short.FailRate())
+	assertClose(t, 0, long.FailRate())
+
+	assertClose(t, 0.722467, short.PassRateLower())
+	assertClose(t, 0.992375, long.PassRateLower())
+	assert.Greater(t, long.PassRateLower(), short.PassRateLower())
+}
+
+func TestWilsonLower(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		successes int
+		total     int
+		want      float64
+	}{
+		{"no data", 0, 0, 0},
+		{"perfect 10", 10, 10, 0.722467},
+		{"perfect 500", 500, 500, 0.992375},
+		{"total failure", 0, 10, 0},
+		{"half of 100", 50, 100, 0.403832},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assertClose(t, tt.want, WilsonLower(tt.successes, tt.total))
+		})
+	}
+}
+
+func TestWilsonLowerIsBoundedToUnitInterval(t *testing.T) {
+	for _, n := range []int{1, 2, 5, 100, 10000} {
+		for _, s := range []int{0, 1, n / 2, n} {
+			if s > n {
+				continue
+			}
+			got := WilsonLower(s, n)
+			assert.False(t, math.IsNaN(got))
+			assert.GreaterOrEqual(t, got, 0.0)
+			assert.LessOrEqual(t, got, 1.0)
+		}
+	}
+}
+
+// A test that never produced a verdict cannot be judged, and asking for a bound
+// on nothing must not yield a NaN that then poisons the sort order.
+func TestWilsonLowerNeverNaN(t *testing.T) {
+	assert.False(t, math.IsNaN(WilsonLower(0, 0)))
+	assert.False(t, math.IsNaN(WilsonLower(-1, 0)))
+	assert.False(t, math.IsNaN(WilsonLower(5, -3)))
+}
+
+func TestLabelsStable(t *testing.T) {
+	th := DefaultThresholds()
+	assert.Equal(t, []string{LabelStable}, th.Labels(Counts{Pass: 50}))
+}
+
+// Zero failures is not enough on its own — three green runs says almost nothing.
+func TestLabelsSparseBeatsStable(t *testing.T) {
+	th := DefaultThresholds()
+	assert.Equal(t, []string{LabelSparse}, th.Labels(Counts{Pass: 3}))
+}
+
+func TestLabelsAlwaysFailing(t *testing.T) {
+	th := DefaultThresholds()
+	labels := th.Labels(Counts{Pass: 1, Fail: 19})
+	assert.Contains(t, labels, LabelAlwaysFailing)
+	assert.NotContains(t, labels, LabelStable)
+}
+
+// The separator the raw fail rate cannot provide: both of these fail often, but
+// only one of them is actually flaky.
+func TestLabelsDistinguishesBrokenFromFlaky(t *testing.T) {
+	th := DefaultThresholds()
+
+	broken := Counts{Fail: 20, Flips: 0, Transitions: 19}
+	flaky := Counts{Pass: 10, Fail: 10, Flips: 15, Transitions: 19}
+
+	assert.Contains(t, th.Labels(broken), LabelAlwaysFailing)
+	assert.NotContains(t, th.Labels(broken), LabelFlaky)
+
+	assert.Contains(t, th.Labels(flaky), LabelFlaky)
+	assert.NotContains(t, th.Labels(flaky), LabelAlwaysFailing)
+}
+
+// Passing and failing at the same commit is flakiness regardless of flip rate:
+// same code, different outcome.
+func TestLabelsFlakyFromSameCommitDisagreement(t *testing.T) {
+	th := DefaultThresholds()
+	c := Counts{Pass: 18, Fail: 2, Flips: 1, Transitions: 19, FlakyCommits: 1}
+	assert.Contains(t, th.Labels(c), LabelFlaky)
+}
+
+func TestLabelsInfraHeavy(t *testing.T) {
+	th := DefaultThresholds()
+	assert.Contains(t, th.Labels(Counts{Pass: 20, Error: 5}), LabelInfraHeavy)
+}
+
+// A handful of errors in a huge sample is background noise, and two errors in
+// seven runs is not yet a pattern. Both guards have to hold independently.
+func TestLabelsInfraHeavyNeedsRateAndCount(t *testing.T) {
+	th := DefaultThresholds()
+	assert.NotContains(t, th.Labels(Counts{Pass: 1000, Error: 2}), LabelInfraHeavy) // rate too low
+	assert.NotContains(t, th.Labels(Counts{Pass: 5, Error: 2}), LabelInfraHeavy)    // count too low
+}
+
+func TestLabelsCanBeMultiple(t *testing.T) {
+	th := DefaultThresholds()
+	c := Counts{Pass: 10, Fail: 10, Error: 6, Flips: 15, Transitions: 19, FlakyCommits: 2}
+	labels := th.Labels(c)
+	assert.Contains(t, labels, LabelFlaky)
+	assert.Contains(t, labels, LabelInfraHeavy)
+}
+
+func TestLabelsNeverNil(t *testing.T) {
+	th := DefaultThresholds()
+	labels := th.Labels(Counts{Pass: 15, Fail: 1})
+	assert.NotNil(t, labels)
+	assert.Empty(t, labels)
+}
+
+// Thresholds are inclusive, so a value sitting exactly on the boundary counts.
+func TestLabelsThresholdsAreInclusive(t *testing.T) {
+	th := DefaultThresholds()
+	assert.Contains(t, th.Labels(Counts{Pass: 1, Fail: 9}), LabelAlwaysFailing) // 0.9 exactly
+	assert.Contains(t, th.Labels(Counts{Pass: 20, Fail: 20, Flips: 8, Transitions: 40}), LabelFlaky)
+}
+
+func TestDefaultThresholds(t *testing.T) {
+	th := DefaultThresholds()
+	assert.Equal(t, 10, th.MinRuns)
+	assertClose(t, 0.9, th.AlwaysFailingRate)
+	assertClose(t, 0.2, th.FlipRate)
+	assertClose(t, 0.1, th.ErrorRate)
+	assert.Equal(t, 3, th.MinErrors)
+}

--- a/internal/analytics/stats.go
+++ b/internal/analytics/stats.go
@@ -1,0 +1,112 @@
+package analytics
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"time"
+)
+
+// TestStats is one row of the analytics table: a single test's record over the
+// query window. The store fills in the identity, Counts, and timestamps; the
+// derived fields come from Finalize, so every rate has exactly one definition.
+type TestStats struct {
+	Repo         string `json:"repo"`
+	ProcedureRef string `json:"procedure_ref"`
+	// EvidenceType is set only when the caller grouped by it.
+	EvidenceType string `json:"evidence_type,omitempty"`
+
+	Counts Counts `json:"counts"`
+
+	Runs        int `json:"runs"`
+	VerdictRuns int `json:"verdict_runs"`
+
+	FailRate      float64 `json:"fail_rate"`
+	ErrorRate     float64 `json:"error_rate"`
+	FlipRate      float64 `json:"flip_rate"`
+	PassRateLower float64 `json:"pass_rate_lower"`
+
+	FirstSeen  time.Time  `json:"first_seen"`
+	LastSeen   time.Time  `json:"last_seen"`
+	LastPassAt *time.Time `json:"last_pass_at,omitempty"`
+	LastFailAt *time.Time `json:"last_fail_at,omitempty"`
+	LastResult string     `json:"last_result"`
+
+	Labels []string `json:"labels"`
+}
+
+// Finalize computes the derived fields for every row in place.
+func Finalize(stats []TestStats, th Thresholds) {
+	for i := range stats {
+		c := stats[i].Counts
+		stats[i].Runs = c.Runs()
+		stats[i].VerdictRuns = c.VerdictRuns()
+		stats[i].FailRate = c.FailRate()
+		stats[i].ErrorRate = c.ErrorRate()
+		stats[i].FlipRate = c.FlipRate()
+		stats[i].PassRateLower = c.PassRateLower()
+		stats[i].Labels = th.Labels(c)
+	}
+}
+
+// DefaultSortKey is neutral on purpose: the endpoint answers several different
+// questions and none of them deserves to be the implicit one.
+const DefaultSortKey = "procedure_ref"
+
+// sortKeys whitelists the orderings the API exposes. Sorting happens here rather
+// than in SQL because the rates are defined in Go, and having one of them
+// computed two ways would be a bug waiting to happen.
+var sortKeys = map[string]func(a, b TestStats) int{
+	"procedure_ref":   func(a, b TestStats) int { return cmp.Compare(a.ProcedureRef, b.ProcedureRef) },
+	"repo":            func(a, b TestStats) int { return cmp.Compare(a.Repo, b.Repo) },
+	"runs":            func(a, b TestStats) int { return cmp.Compare(a.Runs, b.Runs) },
+	"verdict_runs":    func(a, b TestStats) int { return cmp.Compare(a.VerdictRuns, b.VerdictRuns) },
+	"pass":            func(a, b TestStats) int { return cmp.Compare(a.Counts.Pass, b.Counts.Pass) },
+	"fail":            func(a, b TestStats) int { return cmp.Compare(a.Counts.Fail, b.Counts.Fail) },
+	"error":           func(a, b TestStats) int { return cmp.Compare(a.Counts.Error, b.Counts.Error) },
+	"skipped":         func(a, b TestStats) int { return cmp.Compare(a.Counts.Skipped, b.Counts.Skipped) },
+	"flaky_commits":   func(a, b TestStats) int { return cmp.Compare(a.Counts.FlakyCommits, b.Counts.FlakyCommits) },
+	"fail_rate":       func(a, b TestStats) int { return cmp.Compare(a.FailRate, b.FailRate) },
+	"error_rate":      func(a, b TestStats) int { return cmp.Compare(a.ErrorRate, b.ErrorRate) },
+	"flip_rate":       func(a, b TestStats) int { return cmp.Compare(a.FlipRate, b.FlipRate) },
+	"pass_rate_lower": func(a, b TestStats) int { return cmp.Compare(a.PassRateLower, b.PassRateLower) },
+	"first_seen":      func(a, b TestStats) int { return a.FirstSeen.Compare(b.FirstSeen) },
+	"last_seen":       func(a, b TestStats) int { return a.LastSeen.Compare(b.LastSeen) },
+}
+
+// IsSortable reports whether key names an exposed ordering.
+func IsSortable(key string) bool {
+	_, ok := sortKeys[key]
+	return ok
+}
+
+// Sort orders stats in place. An empty key selects DefaultSortKey.
+//
+// The tie-break is always ascending by identity, whichever direction the primary
+// key runs, so that equal values get a stable order and paging through the table
+// neither repeats nor skips a row.
+func Sort(stats []TestStats, key string, desc bool) error {
+	if key == "" {
+		key = DefaultSortKey
+	}
+	compare, ok := sortKeys[key]
+	if !ok {
+		return fmt.Errorf("cannot sort by %q", key)
+	}
+
+	slices.SortStableFunc(stats, func(a, b TestStats) int {
+		c := compare(a, b)
+		if desc {
+			c = -c
+		}
+		if c != 0 {
+			return c
+		}
+		return cmp.Or(
+			cmp.Compare(a.ProcedureRef, b.ProcedureRef),
+			cmp.Compare(a.Repo, b.Repo),
+			cmp.Compare(a.EvidenceType, b.EvidenceType),
+		)
+	})
+	return nil
+}

--- a/internal/analytics/stats_test.go
+++ b/internal/analytics/stats_test.go
@@ -1,0 +1,144 @@
+package analytics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func statsFor(procedure string, c Counts) TestStats {
+	return TestStats{Repo: "org/repo", ProcedureRef: procedure, Counts: c}
+}
+
+func procedureOrder(stats []TestStats) []string {
+	out := make([]string, len(stats))
+	for i, s := range stats {
+		out[i] = s.ProcedureRef
+	}
+	return out
+}
+
+func TestFinalizeDerivesRatesAndLabels(t *testing.T) {
+	stats := []TestStats{
+		statsFor("//a:test", Counts{Pass: 16, Fail: 4, Error: 5, Skipped: 2, Flips: 6, Transitions: 19}),
+	}
+	Finalize(stats, DefaultThresholds())
+
+	s := stats[0]
+	assert.Equal(t, 27, s.Runs)
+	assert.Equal(t, 20, s.VerdictRuns)
+	assertClose(t, 0.2, s.FailRate)
+	assertClose(t, 0.2, s.ErrorRate)
+	assertClose(t, 6.0/19.0, s.FlipRate)
+	assertClose(t, WilsonLower(16, 20), s.PassRateLower)
+	assert.Contains(t, s.Labels, LabelFlaky)
+	assert.Contains(t, s.Labels, LabelInfraHeavy)
+}
+
+func TestFinalizeRespectsCustomThresholds(t *testing.T) {
+	strict := DefaultThresholds()
+	strict.MinRuns = 100
+
+	stats := []TestStats{statsFor("//a:test", Counts{Pass: 50})}
+	Finalize(stats, strict)
+
+	assert.Equal(t, []string{LabelSparse}, stats[0].Labels)
+}
+
+func TestSortByFailRate(t *testing.T) {
+	stats := []TestStats{
+		statsFor("//low:test", Counts{Pass: 19, Fail: 1}),
+		statsFor("//high:test", Counts{Pass: 1, Fail: 19}),
+		statsFor("//mid:test", Counts{Pass: 10, Fail: 10}),
+	}
+	Finalize(stats, DefaultThresholds())
+
+	require.NoError(t, Sort(stats, "fail_rate", true))
+	assert.Equal(t, []string{"//high:test", "//mid:test", "//low:test"}, procedureOrder(stats))
+
+	require.NoError(t, Sort(stats, "fail_rate", false))
+	assert.Equal(t, []string{"//low:test", "//mid:test", "//high:test"}, procedureOrder(stats))
+}
+
+// Ranking "never fails" on the raw pass rate ties every clean test at 1.0; the
+// Wilson bound is what puts the well-evidenced ones on top.
+func TestSortByPassRateLowerRanksEvidence(t *testing.T) {
+	stats := []TestStats{
+		statsFor("//thin:test", Counts{Pass: 12}),
+		statsFor("//thick:test", Counts{Pass: 400}),
+		statsFor("//medium:test", Counts{Pass: 60}),
+	}
+	Finalize(stats, DefaultThresholds())
+
+	require.NoError(t, Sort(stats, "pass_rate_lower", true))
+	assert.Equal(t, []string{"//thick:test", "//medium:test", "//thin:test"}, procedureOrder(stats))
+}
+
+func TestSortByErrorRate(t *testing.T) {
+	stats := []TestStats{
+		statsFor("//clean:test", Counts{Pass: 20}),
+		statsFor("//infra:test", Counts{Pass: 10, Error: 10}),
+	}
+	Finalize(stats, DefaultThresholds())
+
+	require.NoError(t, Sort(stats, "error_rate", true))
+	assert.Equal(t, []string{"//infra:test", "//clean:test"}, procedureOrder(stats))
+}
+
+// Equal sort values must not leave the order up to chance, or paging through the
+// table would repeat and skip rows.
+func TestSortTieBreakIsDeterministic(t *testing.T) {
+	build := func() []TestStats {
+		s := []TestStats{
+			statsFor("//c:test", Counts{Pass: 10}),
+			statsFor("//a:test", Counts{Pass: 10}),
+			statsFor("//b:test", Counts{Pass: 10}),
+		}
+		Finalize(s, DefaultThresholds())
+		return s
+	}
+
+	for _, desc := range []bool{false, true} {
+		stats := build()
+		require.NoError(t, Sort(stats, "fail_rate", desc))
+		assert.Equal(t, []string{"//a:test", "//b:test", "//c:test"}, procedureOrder(stats),
+			"tie-break stays ascending regardless of direction (desc=%v)", desc)
+	}
+}
+
+func TestSortRejectsUnknownKey(t *testing.T) {
+	err := Sort([]TestStats{}, "; DROP TABLE evidence", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sort")
+}
+
+func TestSortEmptyKeyUsesDefault(t *testing.T) {
+	stats := []TestStats{
+		statsFor("//z:test", Counts{Pass: 5}),
+		statsFor("//a:test", Counts{Pass: 5}),
+	}
+	require.NoError(t, Sort(stats, "", false))
+	assert.Equal(t, []string{"//a:test", "//z:test"}, procedureOrder(stats))
+}
+
+func TestSortByLastSeen(t *testing.T) {
+	older := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	stats := []TestStats{
+		{Repo: "org/repo", ProcedureRef: "//old:test", LastSeen: older},
+		{Repo: "org/repo", ProcedureRef: "//new:test", LastSeen: newer},
+	}
+	require.NoError(t, Sort(stats, "last_seen", true))
+	assert.Equal(t, []string{"//new:test", "//old:test"}, procedureOrder(stats))
+}
+
+func TestIsSortable(t *testing.T) {
+	for _, key := range []string{"fail_rate", "error_rate", "flip_rate", "pass_rate_lower", "runs", "procedure_ref", "last_seen"} {
+		assert.True(t, IsSortable(key), key)
+	}
+	assert.False(t, IsSortable("metadata"))
+	assert.False(t, IsSortable(""))
+}

--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "api",
     srcs = [
+        "analytics.go",
         "evidence.go",
         "filter.go",
         "inheritance.go",
@@ -11,6 +12,7 @@ go_library(
     importpath = "github.com/nesono/evidence-store/internal/api",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/analytics",
         "//internal/config",
         "//internal/model",
         "//internal/store",

--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/nesono/evidence-store/internal/analytics"
+	"github.com/nesono/evidence-store/internal/config"
+	"github.com/nesono/evidence-store/internal/store"
+)
+
+type AnalyticsHandler struct {
+	evidence *store.EvidenceStore
+	cfg      *config.Config
+}
+
+func NewAnalyticsHandler(es *store.EvidenceStore, cfg *config.Config) *AnalyticsHandler {
+	return &AnalyticsHandler{evidence: es, cfg: cfg}
+}
+
+// analyticsWindow describes the span the numbers were computed over, so a
+// caller can tell at a glance whether the filter selected what they meant.
+type analyticsWindow struct {
+	From  *time.Time `json:"from,omitempty"`
+	To    *time.Time `json:"to,omitempty"`
+	Runs  int        `json:"runs"`
+	Tests int        `json:"tests"`
+}
+
+// Tests returns one row of reliability metrics per test.
+//
+// It accepts the full evidence filter vocabulary, plus the labelling thresholds,
+// a sort key, and offset paging. Sorting and paging happen in memory: the rates
+// are defined in Go, and computing them a second time in SQL just to order by
+// them is how the two definitions would drift apart.
+func (h *AnalyticsHandler) Tests(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	filter, err := parseEvidenceFilter(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	thresholds, err := parseThresholds(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	sortKey := q.Get("sort")
+	if sortKey != "" && !analytics.IsSortable(sortKey) {
+		writeError(w, http.StatusBadRequest, "cannot sort by "+sortKey)
+		return
+	}
+
+	desc := false
+	switch order := q.Get("order"); order {
+	case "", "asc":
+	case "desc":
+		desc = true
+	default:
+		writeError(w, http.StatusBadRequest, `order must be "asc" or "desc"`)
+		return
+	}
+
+	limit := h.cfg.DefaultPageSize
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 || n > h.cfg.MaxPageSize {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("limit must be between 1 and %d", h.cfg.MaxPageSize))
+			return
+		}
+		limit = n
+	}
+
+	offset := 0
+	if v := q.Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			writeError(w, http.StatusBadRequest, "offset must be a non-negative integer")
+			return
+		}
+		offset = n
+	}
+
+	stats, err := h.evidence.TestStats(r.Context(), store.TestStatsParams{
+		Filter:              filter,
+		GroupByEvidenceType: q.Get("group_by") == "evidence_type",
+	})
+	if err != nil {
+		var tooMany *store.ErrTooManyGroups
+		if errors.As(err, &tooMany) {
+			writeError(w, http.StatusUnprocessableEntity, tooMany.Error())
+			return
+		}
+		slog.Error("failed to aggregate test stats", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	analytics.Finalize(stats, thresholds)
+	if err := analytics.Sort(stats, sortKey, desc); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// The window is derived from the rows already in hand rather than from a
+	// second query, so it always describes exactly the set being reported.
+	window := summarizeWindow(stats)
+
+	page := stats
+	if offset >= len(page) {
+		page = nil
+	} else {
+		page = page[offset:]
+	}
+	if len(page) > limit {
+		page = page[:limit]
+	}
+	if page == nil {
+		page = []analytics.TestStats{}
+	}
+
+	writeJSON(w, http.StatusOK, struct {
+		Window     analyticsWindow       `json:"window"`
+		Thresholds analytics.Thresholds  `json:"thresholds"`
+		Tests      []analytics.TestStats `json:"tests"`
+		Total      int                   `json:"total"`
+	}{
+		Window:     window,
+		Thresholds: thresholds,
+		Tests:      page,
+		Total:      len(stats),
+	})
+}
+
+// Summary returns the headline counts for a filter window.
+func (h *AnalyticsHandler) Summary(w http.ResponseWriter, r *http.Request) {
+	filter, err := parseEvidenceFilter(r.URL.Query())
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	sum, err := h.evidence.Summary(r.Context(), filter)
+	if err != nil {
+		slog.Error("failed to summarize evidence", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// Rates come from the same definitions the per-test table uses.
+	counts := analytics.Counts{
+		Pass:    int(sum.Pass),
+		Fail:    int(sum.Fail),
+		Error:   int(sum.Error),
+		Skipped: int(sum.Skipped),
+	}
+
+	writeJSON(w, http.StatusOK, struct {
+		*store.WindowSummary
+		FailRate  float64 `json:"fail_rate"`
+		ErrorRate float64 `json:"error_rate"`
+	}{
+		WindowSummary: sum,
+		FailRate:      counts.FailRate(),
+		ErrorRate:     counts.ErrorRate(),
+	})
+}
+
+func summarizeWindow(stats []analytics.TestStats) analyticsWindow {
+	window := analyticsWindow{Tests: len(stats)}
+	for _, s := range stats {
+		window.Runs += s.Runs
+		if window.From == nil || s.FirstSeen.Before(*window.From) {
+			first := s.FirstSeen
+			window.From = &first
+		}
+		if window.To == nil || s.LastSeen.After(*window.To) {
+			last := s.LastSeen
+			window.To = &last
+		}
+	}
+	return window
+}
+
+// parseThresholds reads the labelling thresholds, falling back to the defaults.
+// They are request parameters because what counts as "almost always failing" is
+// a judgement about a particular suite, not a universal constant.
+func parseThresholds(q url.Values) (analytics.Thresholds, error) {
+	th := analytics.DefaultThresholds()
+
+	if err := parseIntParam(q, "min_runs", &th.MinRuns, 0); err != nil {
+		return th, err
+	}
+	if err := parseIntParam(q, "min_errors", &th.MinErrors, 0); err != nil {
+		return th, err
+	}
+	if err := parseRateParam(q, "always_failing_rate", &th.AlwaysFailingRate); err != nil {
+		return th, err
+	}
+	if err := parseRateParam(q, "flip_rate", &th.FlipRate); err != nil {
+		return th, err
+	}
+	if err := parseRateParam(q, "error_rate", &th.ErrorRate); err != nil {
+		return th, err
+	}
+
+	return th, nil
+}
+
+func parseIntParam(q url.Values, name string, target *int, min int) error {
+	v := q.Get(name)
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < min {
+		return fmt.Errorf("%s must be an integer >= %d", name, min)
+	}
+	*target = n
+	return nil
+}
+
+func parseRateParam(q url.Values, name string, target *float64) error {
+	v := q.Get(name)
+	if v == "" {
+		return nil
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil || f < 0 || f > 1 {
+		return fmt.Errorf("%s must be a number between 0 and 1", name)
+	}
+	*target = f
+	return nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,6 +45,7 @@ func New(cfg *config.Config, pool *pgxpool.Pool) *Server {
 
 	evidenceAPI := api.NewEvidenceHandler(evidenceStore, inheritanceStore, cfg)
 	inheritanceAPI := api.NewInheritanceHandler(inheritanceStore)
+	analyticsAPI := api.NewAnalyticsHandler(evidenceStore, cfg)
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(auth.Middleware(cfg.APIKeys))
@@ -58,6 +59,9 @@ func New(cfg *config.Config, pool *pgxpool.Pool) *Server {
 
 		r.Post("/inheritance", inheritanceAPI.Create)
 		r.Get("/inheritance", inheritanceAPI.List)
+
+		r.Get("/analytics/summary", analyticsAPI.Summary)
+		r.Get("/analytics/tests", analyticsAPI.Tests)
 	})
 
 	r.Handle("/*", web.StaticHandler())

--- a/internal/store/BUILD.bazel
+++ b/internal/store/BUILD.bazel
@@ -3,13 +3,16 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "store",
     srcs = [
+        "analytics.go",
         "evidence.go",
+        "filter.go",
         "inheritance.go",
         "pagination.go",
     ],
     importpath = "github.com/nesono/evidence-store/internal/store",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/analytics",
         "//internal/model",
         "@com_github_google_uuid//:uuid",
         "@com_github_jackc_pgx_v5//:pgx",

--- a/internal/store/analytics.go
+++ b/internal/store/analytics.go
@@ -1,0 +1,242 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nesono/evidence-store/internal/analytics"
+	"github.com/nesono/evidence-store/internal/model"
+)
+
+// DefaultMaxAnalyticsGroups caps how many distinct tests one aggregation may
+// return. Aggregation collapses millions of rows into thousands of groups, and
+// the caller then sorts and pages that set in memory — but only if it fits.
+// Exceeding the cap is reported rather than silently truncated, because a
+// truncated set produces confident-looking numbers computed from part of the
+// data.
+const DefaultMaxAnalyticsGroups = 50000
+
+// ErrTooManyGroups is returned when an aggregation matches more distinct tests
+// than the cap allows. The caller should narrow the filter or the time window.
+type ErrTooManyGroups struct {
+	Max int
+}
+
+func (e *ErrTooManyGroups) Error() string {
+	return fmt.Sprintf("query matches more than %d distinct tests; narrow the filter or the time window", e.Max)
+}
+
+type TestStatsParams struct {
+	Filter model.EvidenceFilter
+	// GroupByEvidenceType splits a procedure into one row per evidence type,
+	// for when the same procedure runs under several harnesses and their
+	// reliability differs.
+	GroupByEvidenceType bool
+	// MaxGroups overrides DefaultMaxAnalyticsGroups when positive.
+	MaxGroups int
+}
+
+// TestStats aggregates the filtered evidence into one row per test.
+//
+// Only the raw counts and timestamps are filled in; the rates and labels are
+// derived by analytics.Finalize, so SQL never computes a metric that Go also
+// knows how to compute.
+func (s *EvidenceStore) TestStats(ctx context.Context, params TestStatsParams) ([]analytics.TestStats, error) {
+	maxGroups := params.MaxGroups
+	if maxGroups <= 0 {
+		maxGroups = DefaultMaxAnalyticsGroups
+	}
+
+	// Fixed identifiers chosen by a bool, never interpolated from user input.
+	groupCols := []string{"repo", "procedure_ref"}
+	if params.GroupByEvidenceType {
+		groupCols = append(groupCols, "evidence_type")
+	}
+	cols := strings.Join(groupCols, ", ")
+	prefixed := func(alias string) string {
+		out := make([]string, len(groupCols))
+		for i, c := range groupCols {
+			out[i] = alias + "." + c
+		}
+		return strings.Join(out, ", ")
+	}
+
+	f := buildFilter(params.Filter)
+	where := f.whereClause()
+	limit := f.arg(maxGroups + 1)
+
+	// `filtered` is referenced by several branches below, so Postgres materialises
+	// it and the filter scan happens exactly once.
+	//
+	// It projects the group columns and nothing more, so that the common grouping
+	// stays within idx_evidence_analytics and the scan is index-only. Selecting
+	// evidence_type unconditionally would force a heap fetch per row for every
+	// caller, including the ones not grouping by it.
+	query := fmt.Sprintf(`
+WITH filtered AS (
+    SELECT %[1]s, rcs_ref, result, finished_at, id
+    FROM evidence%[2]s
+),
+agg AS (
+    SELECT %[1]s,
+        count(*) FILTER (WHERE result = 'PASS')::int    AS pass_count,
+        count(*) FILTER (WHERE result = 'FAIL')::int    AS fail_count,
+        count(*) FILTER (WHERE result = 'ERROR')::int   AS error_count,
+        count(*) FILTER (WHERE result = 'SKIPPED')::int AS skipped_count,
+        min(finished_at)                                AS first_seen,
+        max(finished_at)                                AS last_seen,
+        max(finished_at) FILTER (WHERE result = 'PASS') AS last_pass_at,
+        max(finished_at) FILTER (WHERE result = 'FAIL') AS last_fail_at
+    FROM filtered
+    GROUP BY %[1]s
+),
+-- Consecutive verdict changes. ERROR and SKIPPED are dropped first so an
+-- infrastructure blip between two passes does not read as two flips.
+sequenced AS (
+    SELECT %[1]s, result,
+        lag(result) OVER (PARTITION BY %[1]s ORDER BY finished_at, id) AS prev
+    FROM filtered
+    WHERE result IN ('PASS', 'FAIL')
+),
+flips AS (
+    SELECT %[1]s,
+        count(*) FILTER (WHERE prev IS NOT NULL AND result <> prev)::int AS flips,
+        count(*) FILTER (WHERE prev IS NOT NULL)::int                    AS transitions
+    FROM sequenced
+    GROUP BY %[1]s
+),
+-- Commits where the same test both passed and failed: same code, different
+-- outcome, which is flakiness no matter what the flip rate says.
+disagreements AS (
+    SELECT %[1]s, count(*)::int AS flaky_commits
+    FROM (
+        SELECT %[1]s, rcs_ref
+        FROM filtered
+        GROUP BY %[1]s, rcs_ref
+        HAVING count(*) FILTER (WHERE result = 'PASS') > 0
+           AND count(*) FILTER (WHERE result = 'FAIL') > 0
+    ) per_commit
+    GROUP BY %[1]s
+),
+latest AS (
+    SELECT DISTINCT ON (%[1]s) %[1]s, result AS last_result
+    FROM filtered
+    ORDER BY %[1]s, finished_at DESC, id DESC
+)
+SELECT %[3]s,
+    a.pass_count, a.fail_count, a.error_count, a.skipped_count,
+    COALESCE(f.flips, 0), COALESCE(f.transitions, 0), COALESCE(d.flaky_commits, 0),
+    a.first_seen, a.last_seen, a.last_pass_at, a.last_fail_at, l.last_result
+FROM agg a
+LEFT JOIN flips f USING (%[1]s)
+LEFT JOIN disagreements d USING (%[1]s)
+LEFT JOIN latest l USING (%[1]s)
+LIMIT %[4]s`, cols, where, prefixed("a"), limit)
+
+	rows, err := s.pool.Query(ctx, query, f.args...)
+	if err != nil {
+		return nil, fmt.Errorf("query test stats: %w", err)
+	}
+	defer rows.Close()
+
+	stats := make([]analytics.TestStats, 0)
+	for rows.Next() {
+		var (
+			st                     analytics.TestStats
+			lastPassAt, lastFailAt *time.Time
+		)
+
+		dest := []any{&st.Repo, &st.ProcedureRef}
+		if params.GroupByEvidenceType {
+			dest = append(dest, &st.EvidenceType)
+		}
+		dest = append(dest,
+			&st.Counts.Pass, &st.Counts.Fail, &st.Counts.Error, &st.Counts.Skipped,
+			&st.Counts.Flips, &st.Counts.Transitions, &st.Counts.FlakyCommits,
+			&st.FirstSeen, &st.LastSeen, &lastPassAt, &lastFailAt, &st.LastResult,
+		)
+
+		if err := rows.Scan(dest...); err != nil {
+			return nil, fmt.Errorf("scan test stats: %w", err)
+		}
+
+		st.FirstSeen = st.FirstSeen.UTC()
+		st.LastSeen = st.LastSeen.UTC()
+		st.LastPassAt = utcPtr(lastPassAt)
+		st.LastFailAt = utcPtr(lastFailAt)
+
+		stats = append(stats, st)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate test stats: %w", err)
+	}
+
+	if len(stats) > maxGroups {
+		return nil, &ErrTooManyGroups{Max: maxGroups}
+	}
+
+	return stats, nil
+}
+
+// WindowSummary is the headline shape of a query window.
+type WindowSummary struct {
+	Runs    int64 `json:"runs"`
+	Pass    int64 `json:"pass"`
+	Fail    int64 `json:"fail"`
+	Error   int64 `json:"error"`
+	Skipped int64 `json:"skipped"`
+
+	Tests   int64 `json:"tests"`
+	Repos   int64 `json:"repos"`
+	Commits int64 `json:"commits"`
+
+	FirstSeen *time.Time `json:"first_seen,omitempty"`
+	LastSeen  *time.Time `json:"last_seen,omitempty"`
+}
+
+// Summary counts the filtered evidence without grouping it.
+func (s *EvidenceStore) Summary(ctx context.Context, filter model.EvidenceFilter) (*WindowSummary, error) {
+	f := buildFilter(filter)
+
+	query := `
+SELECT
+    count(*)::bigint,
+    count(*) FILTER (WHERE result = 'PASS')::bigint,
+    count(*) FILTER (WHERE result = 'FAIL')::bigint,
+    count(*) FILTER (WHERE result = 'ERROR')::bigint,
+    count(*) FILTER (WHERE result = 'SKIPPED')::bigint,
+    count(DISTINCT (repo, procedure_ref))::bigint,
+    count(DISTINCT repo)::bigint,
+    count(DISTINCT rcs_ref)::bigint,
+    min(finished_at),
+    max(finished_at)
+FROM evidence` + f.whereClause()
+
+	var (
+		sum                 WindowSummary
+		firstSeen, lastSeen *time.Time
+	)
+	err := s.pool.QueryRow(ctx, query, f.args...).Scan(
+		&sum.Runs, &sum.Pass, &sum.Fail, &sum.Error, &sum.Skipped,
+		&sum.Tests, &sum.Repos, &sum.Commits,
+		&firstSeen, &lastSeen,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query summary: %w", err)
+	}
+
+	sum.FirstSeen = utcPtr(firstSeen)
+	sum.LastSeen = utcPtr(lastSeen)
+
+	return &sum, nil
+}
+
+func utcPtr(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	utc := t.UTC()
+	return &utc
+}

--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -123,103 +122,26 @@ type ListResult struct {
 }
 
 func (s *EvidenceStore) List(ctx context.Context, params ListParams) (*ListResult, error) {
-	var (
-		where []string
-		args  []any
-		argN  = 1
-	)
+	f := buildFilter(params.Filter)
 
-	arg := func(v any) string {
-		args = append(args, v)
-		s := fmt.Sprintf("$%d", argN)
-		argN++
-		return s
-	}
-
-	textFilter := func(column string, v *string) {
-		if v == nil {
-			return
-		}
-		val := *v
-		if strings.HasPrefix(val, "~") {
-			where = append(where, fmt.Sprintf("%s ~ %s", column, arg(val[1:])))
-		} else {
-			where = append(where, fmt.Sprintf("%s = %s", column, arg(val)))
-		}
-	}
-
-	textFilter("repo", params.Filter.Repo)
-	textFilter("rcs_ref", params.Filter.RCSRef)
-	textFilter("branch", params.Filter.Branch)
-	textFilter("evidence_type", params.Filter.EvidenceType)
-	textFilter("source", params.Filter.Source)
-	if v := params.Filter.ProcedureRef; v != nil {
-		val := *v
-		if strings.HasPrefix(val, "~") {
-			where = append(where, fmt.Sprintf("procedure_ref ~ %s", arg(val[1:])))
-		} else if strings.HasSuffix(val, "*") {
-			prefix := strings.TrimSuffix(val, "*")
-			where = append(where, fmt.Sprintf("procedure_ref LIKE %s", arg(prefix+"%")))
-		} else {
-			where = append(where, fmt.Sprintf("procedure_ref = %s", arg(val)))
-		}
-	}
-	if len(params.Filter.Result) > 0 {
-		placeholders := make([]string, len(params.Filter.Result))
-		for i, r := range params.Filter.Result {
-			placeholders[i] = arg(r)
-		}
-		where = append(where, fmt.Sprintf("result IN (%s)", strings.Join(placeholders, ",")))
-	}
-	if v := params.Filter.FinishedAfter; v != nil {
-		where = append(where, fmt.Sprintf("finished_at >= %s", arg(*v)))
-	}
-	if v := params.Filter.FinishedBefore; v != nil {
-		where = append(where, fmt.Sprintf("finished_at < %s", arg(*v)))
-	}
-	if len(params.Filter.Tags) > 0 {
-		// If the first tag starts with ~, treat all tags as regex patterns.
-		if strings.HasPrefix(params.Filter.Tags[0], "~") {
-			for _, t := range params.Filter.Tags {
-				pattern := strings.TrimPrefix(t, "~")
-				where = append(where, fmt.Sprintf("EXISTS (SELECT 1 FROM jsonb_array_elements_text(metadata->'tags') tag WHERE tag ~ %s)", arg(pattern)))
-			}
-		} else {
-			where = append(where, fmt.Sprintf("metadata->'tags' @> %s", arg(mustJSON(params.Filter.Tags))))
-		}
-	}
-	if v := params.Filter.Notes; v != nil {
-		val := *v
-		if strings.HasPrefix(val, "~") {
-			where = append(where, fmt.Sprintf("metadata->>'notes' ~ %s", arg(val[1:])))
-		} else {
-			where = append(where, fmt.Sprintf("metadata->>'notes' = %s", arg(val)))
-		}
-	}
 	// Count matching records before adding pagination clauses. Only done when the
 	// caller asks for it — pages after the first keep the total from the initial
 	// call so we don't recount on every "next page" click.
 	var total *int64
 	if params.WithTotal {
-		countQuery := "SELECT COUNT(*) FROM evidence"
-		if len(where) > 0 {
-			countQuery += " WHERE " + strings.Join(where, " AND ")
-		}
+		countQuery := "SELECT COUNT(*) FROM evidence" + f.whereClause()
 		var n int64
-		if err := s.pool.QueryRow(ctx, countQuery, args...).Scan(&n); err != nil {
+		if err := s.pool.QueryRow(ctx, countQuery, f.args...).Scan(&n); err != nil {
 			return nil, fmt.Errorf("count evidence: %w", err)
 		}
 		total = &n
 	}
 
 	if params.Cursor != nil {
-		where = append(where, fmt.Sprintf("(ingested_at, id) > (%s, %s)", arg(params.Cursor.IngestedAt), arg(params.Cursor.ID)))
+		f.add(fmt.Sprintf("(ingested_at, id) > (%s, %s)", f.arg(params.Cursor.IngestedAt), f.arg(params.Cursor.ID)))
 	}
 
-	query := "SELECT id, repo, branch, rcs_ref, procedure_ref, evidence_type, source, result, finished_at, ingested_at, metadata FROM evidence"
-	if len(where) > 0 {
-		query += " WHERE " + strings.Join(where, " AND ")
-	}
+	query := "SELECT id, repo, branch, rcs_ref, procedure_ref, evidence_type, source, result, finished_at, ingested_at, metadata FROM evidence" + f.whereClause()
 
 	// id breaks ties so the total order is deterministic and offset windows
 	// neither repeat nor skip records.
@@ -239,12 +161,12 @@ func (s *EvidenceStore) List(ctx context.Context, params ListParams) (*ListResul
 		query += fmt.Sprintf(" ORDER BY %s %s, id %s", params.Sort, direction, direction)
 	}
 
-	query += fmt.Sprintf(" LIMIT %s", arg(params.Limit+1))
+	query += fmt.Sprintf(" LIMIT %s", f.arg(params.Limit+1))
 	if params.Offset > 0 && params.Cursor == nil {
-		query += fmt.Sprintf(" OFFSET %s", arg(params.Offset))
+		query += fmt.Sprintf(" OFFSET %s", f.arg(params.Offset))
 	}
 
-	rows, err := s.pool.Query(ctx, query, args...)
+	rows, err := s.pool.Query(ctx, query, f.args...)
 	if err != nil {
 		return nil, fmt.Errorf("query evidence: %w", err)
 	}

--- a/internal/store/filter.go
+++ b/internal/store/filter.go
@@ -1,0 +1,118 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nesono/evidence-store/internal/model"
+)
+
+// sqlFilter accumulates WHERE conditions and their bind arguments. It is shared
+// by the list and analytics queries so both interpret the filter vocabulary —
+// `~` regex, `*` prefix on procedure_ref, tag containment — identically.
+//
+// Callers may keep appending conditions after applying a filter; argument
+// numbering continues from wherever the filter left off.
+type sqlFilter struct {
+	where []string
+	args  []any
+}
+
+// arg registers a bind argument and returns its placeholder.
+func (f *sqlFilter) arg(v any) string {
+	f.args = append(f.args, v)
+	return fmt.Sprintf("$%d", len(f.args))
+}
+
+// add appends a raw condition. The caller is responsible for binding any values
+// through arg rather than interpolating them.
+func (f *sqlFilter) add(condition string) {
+	f.where = append(f.where, condition)
+}
+
+// whereClause renders the accumulated conditions, including the leading
+// " WHERE ", or the empty string when there are none.
+func (f *sqlFilter) whereClause() string {
+	if len(f.where) == 0 {
+		return ""
+	}
+	return " WHERE " + strings.Join(f.where, " AND ")
+}
+
+// buildFilter translates an EvidenceFilter into SQL conditions.
+func buildFilter(filter model.EvidenceFilter) *sqlFilter {
+	f := &sqlFilter{}
+
+	// A leading `~` switches an exact match to a POSIX regex match.
+	textFilter := func(column string, v *string) {
+		if v == nil {
+			return
+		}
+		val := *v
+		if strings.HasPrefix(val, "~") {
+			f.add(fmt.Sprintf("%s ~ %s", column, f.arg(val[1:])))
+		} else {
+			f.add(fmt.Sprintf("%s = %s", column, f.arg(val)))
+		}
+	}
+
+	textFilter("repo", filter.Repo)
+	textFilter("rcs_ref", filter.RCSRef)
+	textFilter("branch", filter.Branch)
+	textFilter("evidence_type", filter.EvidenceType)
+	textFilter("source", filter.Source)
+
+	// procedure_ref additionally supports a trailing `*` for prefix matching,
+	// which is how callers select a whole Bazel package.
+	if v := filter.ProcedureRef; v != nil {
+		val := *v
+		if strings.HasPrefix(val, "~") {
+			f.add(fmt.Sprintf("procedure_ref ~ %s", f.arg(val[1:])))
+		} else if strings.HasSuffix(val, "*") {
+			prefix := strings.TrimSuffix(val, "*")
+			f.add(fmt.Sprintf("procedure_ref LIKE %s", f.arg(prefix+"%")))
+		} else {
+			f.add(fmt.Sprintf("procedure_ref = %s", f.arg(val)))
+		}
+	}
+
+	if len(filter.Result) > 0 {
+		placeholders := make([]string, len(filter.Result))
+		for i, r := range filter.Result {
+			placeholders[i] = f.arg(r)
+		}
+		f.add(fmt.Sprintf("result IN (%s)", strings.Join(placeholders, ",")))
+	}
+
+	if v := filter.FinishedAfter; v != nil {
+		f.add(fmt.Sprintf("finished_at >= %s", f.arg(*v)))
+	}
+	if v := filter.FinishedBefore; v != nil {
+		f.add(fmt.Sprintf("finished_at < %s", f.arg(*v)))
+	}
+
+	if len(filter.Tags) > 0 {
+		// If the first tag starts with ~, treat all tags as regex patterns.
+		if strings.HasPrefix(filter.Tags[0], "~") {
+			for _, t := range filter.Tags {
+				pattern := strings.TrimPrefix(t, "~")
+				f.add(fmt.Sprintf(
+					"EXISTS (SELECT 1 FROM jsonb_array_elements_text(metadata->'tags') tag WHERE tag ~ %s)",
+					f.arg(pattern)))
+			}
+		} else {
+			f.add(fmt.Sprintf("metadata->'tags' @> %s", f.arg(mustJSON(filter.Tags))))
+		}
+	}
+
+	if v := filter.Notes; v != nil {
+		val := *v
+		if strings.HasPrefix(val, "~") {
+			f.add(fmt.Sprintf("metadata->>'notes' ~ %s", f.arg(val[1:])))
+		} else {
+			f.add(fmt.Sprintf("metadata->>'notes' = %s", f.arg(val)))
+		}
+	}
+
+	return f
+}

--- a/migrations/000004_add_analytics_index.down.sql
+++ b/migrations/000004_add_analytics_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_evidence_analytics;

--- a/migrations/000004_add_analytics_index.up.sql
+++ b/migrations/000004_add_analytics_index.up.sql
@@ -1,0 +1,25 @@
+-- The analytics aggregation filters by repo and a time window, then groups by
+-- procedure_ref and walks each group in finished_at order. Before this index the
+-- planner bitmap-ANDed idx_evidence_repo with idx_evidence_finished_at and then
+-- visited 32k heap blocks, and the ordering had to be re-established with an
+-- external merge sort that spilled to disk.
+--
+-- Leading with the group key rather than the time column is what earns most of
+-- the win: it supplies the GROUP BY and the DISTINCT ON ordering directly. The
+-- INCLUDE columns are what make the scan index-only -- measured without them the
+-- planner ignored this index entirely and fell back to the bitmap scan.
+--
+-- Measured on 1,000,000 rows (12 repos, 88 procedures, 70k rows matching a
+-- 90-day window):
+--
+--     no index                              450 ms
+--     (repo, finished_at) INCLUDE (...)     328 ms   155 MB
+--     this index, without INCLUDE           450 ms    79 MB  (planner ignores it)
+--     this index                            197 ms   149 MB  Heap Fetches: 0
+--
+-- The cost is index size: roughly half the table's own size again. Deployments
+-- that do not use the analytics endpoints can drop this index; the queries still
+-- work, just at the 450 ms figure above.
+CREATE INDEX idx_evidence_analytics
+    ON evidence (repo, procedure_ref, finished_at DESC)
+    INCLUDE (result, rcs_ref, id);

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_test")
 go_test(
     name = "tests_test",
     srcs = [
+        "analytics_integration_test.go",
         "auth_integration_test.go",
         "distinct_test.go",
         "integration_test.go",
@@ -17,6 +18,7 @@ go_test(
         "requires-docker",
     ],
     deps = [
+        "//internal/analytics",
         "//internal/config",
         "//internal/migrate",
         "//internal/model",

--- a/tests/analytics_integration_test.go
+++ b/tests/analytics_integration_test.go
@@ -1,0 +1,410 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nesono/evidence-store/internal/analytics"
+	"github.com/nesono/evidence-store/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture
+//
+// One repo containing one test of each kind we claim to detect. Every count in
+// the assertions below is hand-derived from this fixture, so a change in the
+// aggregation shows up as a specific wrong number rather than a vague failure.
+// ---------------------------------------------------------------------------
+
+type analyticsFixture struct {
+	repo string
+}
+
+var fixtureBase = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+func seedAnalyticsFixture(t *testing.T) analyticsFixture {
+	t.Helper()
+
+	repo := fmt.Sprintf("analytics/%d", time.Now().UnixNano())
+	var records []model.EvidenceCreate
+
+	// finished_at increases by one minute per record, so the ordered scan that
+	// computes flips has an unambiguous sequence to walk.
+	minute := 0
+	add := func(procedure, commit string, result model.EvidenceResult) {
+		records = append(records, model.EvidenceCreate{
+			Repo:         repo,
+			Branch:       "main",
+			RCSRef:       commit,
+			ProcedureRef: procedure,
+			EvidenceType: "bazel",
+			Source:       "ci",
+			Result:       result,
+			FinishedAt:   model.FlexibleTime{Time: fixtureBase.Add(time.Duration(minute) * time.Minute)},
+		})
+		minute++
+	}
+
+	// Never fails: 20 passes over 20 commits.
+	for i := range 20 {
+		add("//stable:test", fmt.Sprintf("s%02d", i), model.ResultPass)
+	}
+
+	// Always fails: 20 failures, no flips — broken, not flaky.
+	for i := range 20 {
+		add("//broken:test", fmt.Sprintf("b%02d", i), model.ResultFail)
+	}
+
+	// Flaky by alternation: every consecutive pair changes verdict.
+	for i := range 20 {
+		result := model.ResultPass
+		if i%2 == 1 {
+			result = model.ResultFail
+		}
+		add("//flaky:test", fmt.Sprintf("f%02d", i), result)
+	}
+
+	// Flaky by disagreement at one commit, and only that: the flip rate stays
+	// below the threshold, so this test is detected purely by same-commit
+	// contradiction.
+	add("//disagree:test", "d00", model.ResultPass)
+	add("//disagree:test", "d00", model.ResultFail)
+	for i := 1; i < 19; i++ {
+		add("//disagree:test", fmt.Sprintf("d%02d", i), model.ResultPass)
+	}
+
+	// Infrastructure-heavy: half its runs never produced a verdict.
+	for i := range 10 {
+		add("//infra:test", fmt.Sprintf("i%02d", i), model.ResultPass)
+	}
+	for i := 10; i < 20; i++ {
+		add("//infra:test", fmt.Sprintf("i%02d", i), model.ResultError)
+	}
+
+	// Too little history to judge.
+	for i := range 3 {
+		add("//sparse:test", fmt.Sprintf("p%02d", i), model.ResultPass)
+	}
+
+	_, err := testEvidenceStore.InsertBatch(context.Background(), records)
+	require.NoError(t, err)
+
+	return analyticsFixture{repo: repo}
+}
+
+type analyticsTestsResponse struct {
+	Window struct {
+		From  *time.Time `json:"from"`
+		To    *time.Time `json:"to"`
+		Runs  int        `json:"runs"`
+		Tests int        `json:"tests"`
+	} `json:"window"`
+	Thresholds analytics.Thresholds  `json:"thresholds"`
+	Tests      []analytics.TestStats `json:"tests"`
+	Total      int                   `json:"total"`
+}
+
+func (f analyticsFixture) get(t *testing.T, extra url.Values) analyticsTestsResponse {
+	t.Helper()
+	q := url.Values{"repo": {f.repo}}
+	for k, vs := range extra {
+		q[k] = vs
+	}
+	resp := getJSON(t, "/api/v1/analytics/tests?"+q.Encode())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return decodeJSON[analyticsTestsResponse](t, resp)
+}
+
+func byProcedure(t *testing.T, body analyticsTestsResponse, procedure string) analytics.TestStats {
+	t.Helper()
+	for _, s := range body.Tests {
+		if s.ProcedureRef == procedure {
+			return s
+		}
+	}
+	t.Fatalf("no stats returned for %s", procedure)
+	return analytics.TestStats{}
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsAggregatesOneRowPerTest(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	body := f.get(t, nil)
+
+	assert.Equal(t, 6, body.Total)
+	assert.Equal(t, 6, body.Window.Tests)
+	assert.Equal(t, 103, body.Window.Runs)
+
+	require.NotNil(t, body.Window.From)
+	require.NotNil(t, body.Window.To)
+	assert.Equal(t, fixtureBase.UTC(), body.Window.From.UTC())
+	assert.Equal(t, fixtureBase.Add(102*time.Minute).UTC(), body.Window.To.UTC())
+}
+
+func TestAnalyticsNeverFailingTest(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	s := byProcedure(t, f.get(t, nil), "//stable:test")
+
+	assert.Equal(t, 20, s.Counts.Pass)
+	assert.Zero(t, s.Counts.Fail)
+	assert.Zero(t, s.Counts.Error)
+	assert.Equal(t, 20, s.VerdictRuns)
+	assert.InDelta(t, 0, s.FailRate, 1e-9)
+	assert.InDelta(t, 0, s.FlipRate, 1e-9)
+	assert.Equal(t, 19, s.Counts.Transitions)
+	assert.Zero(t, s.Counts.Flips)
+	assert.InDelta(t, analytics.WilsonLower(20, 20), s.PassRateLower, 1e-9)
+	assert.Equal(t, []string{analytics.LabelStable}, s.Labels)
+	assert.Equal(t, "PASS", s.LastResult)
+	assert.Nil(t, s.LastFailAt)
+	require.NotNil(t, s.LastPassAt)
+}
+
+func TestAnalyticsAlwaysFailingTest(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	s := byProcedure(t, f.get(t, nil), "//broken:test")
+
+	assert.Equal(t, 20, s.Counts.Fail)
+	assert.InDelta(t, 1.0, s.FailRate, 1e-9)
+	assert.Contains(t, s.Labels, analytics.LabelAlwaysFailing)
+
+	// The distinction the fail rate alone cannot make.
+	assert.InDelta(t, 0, s.FlipRate, 1e-9)
+	assert.NotContains(t, s.Labels, analytics.LabelFlaky)
+	assert.Equal(t, "FAIL", s.LastResult)
+	assert.Nil(t, s.LastPassAt)
+}
+
+func TestAnalyticsFlakyByAlternation(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	s := byProcedure(t, f.get(t, nil), "//flaky:test")
+
+	assert.Equal(t, 10, s.Counts.Pass)
+	assert.Equal(t, 10, s.Counts.Fail)
+	assert.Equal(t, 19, s.Counts.Transitions)
+	assert.Equal(t, 19, s.Counts.Flips, "every consecutive pair alternates")
+	assert.InDelta(t, 1.0, s.FlipRate, 1e-9)
+	assert.Contains(t, s.Labels, analytics.LabelFlaky)
+	assert.NotContains(t, s.Labels, analytics.LabelAlwaysFailing)
+}
+
+// Same commit, both outcomes. The flip rate here is 2/19, below the threshold,
+// so this test is caught only by the same-commit contradiction.
+func TestAnalyticsFlakyBySameCommitDisagreement(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	s := byProcedure(t, f.get(t, nil), "//disagree:test")
+
+	assert.Equal(t, 19, s.Counts.Pass)
+	assert.Equal(t, 1, s.Counts.Fail)
+	assert.Equal(t, 1, s.Counts.FlakyCommits)
+	assert.Equal(t, 2, s.Counts.Flips)
+	assert.Equal(t, 19, s.Counts.Transitions)
+	assert.Less(t, s.FlipRate, analytics.DefaultThresholds().FlipRate)
+	assert.Contains(t, s.Labels, analytics.LabelFlaky)
+}
+
+func TestAnalyticsInfrastructureHeavyTest(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	s := byProcedure(t, f.get(t, nil), "//infra:test")
+
+	assert.Equal(t, 10, s.Counts.Error)
+	assert.Equal(t, 20, s.Runs)
+	assert.Equal(t, 10, s.VerdictRuns)
+	assert.InDelta(t, 0.5, s.ErrorRate, 1e-9)
+	assert.InDelta(t, 0, s.FailRate, 1e-9, "errors must not count as failures")
+	assert.Contains(t, s.Labels, analytics.LabelInfraHeavy)
+
+	// ERROR rows are dropped before the sequence is walked, so an infrastructure
+	// blip between two passes is not two flips.
+	assert.Zero(t, s.Counts.Flips)
+	assert.Equal(t, 9, s.Counts.Transitions)
+}
+
+func TestAnalyticsSparseTestIsNotCalledStable(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	s := byProcedure(t, f.get(t, nil), "//sparse:test")
+
+	assert.Equal(t, 3, s.Counts.Pass)
+	assert.Equal(t, []string{analytics.LabelSparse}, s.Labels)
+	assert.NotContains(t, s.Labels, analytics.LabelStable)
+}
+
+// ---------------------------------------------------------------------------
+// Query surface
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsSortByFailRate(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	body := f.get(t, url.Values{"sort": {"fail_rate"}, "order": {"desc"}})
+
+	require.NotEmpty(t, body.Tests)
+	assert.Equal(t, "//broken:test", body.Tests[0].ProcedureRef)
+}
+
+func TestAnalyticsSortByErrorRate(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	body := f.get(t, url.Values{"sort": {"error_rate"}, "order": {"desc"}})
+
+	require.NotEmpty(t, body.Tests)
+	assert.Equal(t, "//infra:test", body.Tests[0].ProcedureRef)
+}
+
+// Ranking the clean tests by Wilson bound puts the well-evidenced one first,
+// where the raw pass rate would tie them at 1.0.
+func TestAnalyticsSortByPassRateLower(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	body := f.get(t, url.Values{"sort": {"pass_rate_lower"}, "order": {"desc"}})
+
+	require.NotEmpty(t, body.Tests)
+	assert.Equal(t, "//stable:test", body.Tests[0].ProcedureRef)
+
+	stable := byProcedure(t, body, "//stable:test")
+	sparse := byProcedure(t, body, "//sparse:test")
+	assert.Greater(t, stable.PassRateLower, sparse.PassRateLower)
+}
+
+func TestAnalyticsPagingWindowsTheSortedSet(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+
+	all := f.get(t, url.Values{"sort": {"procedure_ref"}})
+	require.Len(t, all.Tests, 6)
+
+	page := f.get(t, url.Values{"sort": {"procedure_ref"}, "limit": {"2"}, "offset": {"2"}})
+	assert.Equal(t, 6, page.Total, "total describes the whole set, not the page")
+	require.Len(t, page.Tests, 2)
+	assert.Equal(t, all.Tests[2].ProcedureRef, page.Tests[0].ProcedureRef)
+	assert.Equal(t, all.Tests[3].ProcedureRef, page.Tests[1].ProcedureRef)
+}
+
+func TestAnalyticsOffsetPastEndReturnsEmptySet(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	body := f.get(t, url.Values{"offset": {"500"}})
+
+	assert.Equal(t, 6, body.Total)
+	assert.Empty(t, body.Tests)
+	assert.NotNil(t, body.Tests, "an empty page is [] rather than null")
+}
+
+func TestAnalyticsThresholdsAreRequestParameters(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+
+	body := f.get(t, url.Values{"min_runs": {"25"}})
+	assert.Equal(t, 25, body.Thresholds.MinRuns)
+
+	// Nothing in the fixture reaches 25 verdicts, so everything is now sparse.
+	stable := byProcedure(t, body, "//stable:test")
+	assert.Equal(t, []string{analytics.LabelSparse}, stable.Labels)
+}
+
+func TestAnalyticsRespectsEvidenceFilters(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+
+	body := f.get(t, url.Values{"procedure_ref": {"//stable:test"}})
+	require.Len(t, body.Tests, 1)
+	assert.Equal(t, "//stable:test", body.Tests[0].ProcedureRef)
+
+	// Regex form, shared with the list endpoint.
+	body = f.get(t, url.Values{"procedure_ref": {"~^//(stable|broken):"}})
+	assert.Len(t, body.Tests, 2)
+}
+
+func TestAnalyticsTimeWindowNarrowsTheCounts(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+
+	// The first ten records are all //stable:test.
+	body := f.get(t, url.Values{
+		"finished_before": {fixtureBase.Add(10 * time.Minute).Format(time.RFC3339)},
+	})
+	require.Len(t, body.Tests, 1)
+	assert.Equal(t, "//stable:test", body.Tests[0].ProcedureRef)
+	assert.Equal(t, 10, body.Tests[0].Counts.Pass)
+}
+
+func TestAnalyticsGroupByEvidenceType(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+
+	body := f.get(t, url.Values{"group_by": {"evidence_type"}})
+	require.NotEmpty(t, body.Tests)
+	for _, s := range body.Tests {
+		assert.Equal(t, "bazel", s.EvidenceType)
+	}
+}
+
+func TestAnalyticsRejectsUnknownSortKey(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	resp := getJSON(t, "/api/v1/analytics/tests?repo="+url.QueryEscape(f.repo)+"&sort=metadata")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestAnalyticsRejectsInvalidThreshold(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	for _, param := range []string{"flip_rate=2", "error_rate=-1", "min_runs=abc"} {
+		resp := getJSON(t, "/api/v1/analytics/tests?repo="+url.QueryEscape(f.repo)+"&"+param)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, param)
+	}
+}
+
+func TestAnalyticsRejectsInvalidFilter(t *testing.T) {
+	resp := getJSON(t, "/api/v1/analytics/tests?result=BOGUS")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+type analyticsSummaryResponse struct {
+	Runs      int64   `json:"runs"`
+	Pass      int64   `json:"pass"`
+	Fail      int64   `json:"fail"`
+	Error     int64   `json:"error"`
+	Skipped   int64   `json:"skipped"`
+	Tests     int64   `json:"tests"`
+	Repos     int64   `json:"repos"`
+	Commits   int64   `json:"commits"`
+	FailRate  float64 `json:"fail_rate"`
+	ErrorRate float64 `json:"error_rate"`
+}
+
+func TestAnalyticsSummary(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+
+	resp := getJSON(t, "/api/v1/analytics/summary?repo="+url.QueryEscape(f.repo))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeJSON[analyticsSummaryResponse](t, resp)
+
+	assert.Equal(t, int64(103), body.Runs)
+	assert.Equal(t, int64(62), body.Pass)
+	assert.Equal(t, int64(31), body.Fail)
+	assert.Equal(t, int64(10), body.Error)
+	assert.Equal(t, int64(0), body.Skipped)
+	assert.Equal(t, int64(6), body.Tests)
+	assert.Equal(t, int64(1), body.Repos)
+	assert.Equal(t, int64(102), body.Commits)
+
+	assert.InDelta(t, 31.0/93.0, body.FailRate, 1e-9)
+	assert.InDelta(t, 10.0/103.0, body.ErrorRate, 1e-9)
+}
+
+func TestAnalyticsSummaryEmptyWindow(t *testing.T) {
+	resp := getJSON(t, "/api/v1/analytics/summary?repo=analytics/does-not-exist")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeJSON[analyticsSummaryResponse](t, resp)
+
+	assert.Zero(t, body.Runs)
+	assert.Zero(t, body.Tests)
+	assert.InDelta(t, 0, body.FailRate, 1e-9)
+}


### PR DESCRIPTION
Phase 1 of `docs/analytics-plan.md`, for #58. Follows #62 (merged); rebased onto `main`, so the diff here is phase 1 only.

Answers three of the four questions in the issue: which tests never fail, which are chronically broken, and which lose the most runs to infrastructure. Co-failure clustering is phase 2.

## Endpoints

```
GET /api/v1/analytics/summary   headline counts for a filter window
GET /api/v1/analytics/tests     one row of reliability metrics per test
```

Both accept the full evidence filter vocabulary via the parser extracted in #62 — including `~` regex and `*` prefix — so analytics and Search stay consistent for free.

Backend only. The UI is phase 3.

## The one architectural decision

**SQL counts, Go divides.** One aggregation pass produces the raw tallies — including `flips` and `transitions` as separate counts from the `lag()` scan — and every rate, bound, and label is a pure function in `internal/analytics`.

Each metric is therefore defined in exactly one place and unit-testable without a database. Sorting is in Go for the same reason: ordering by `fail_rate` in SQL would write that definition a second time, in a second language, where the two could drift apart. The cost is that paging happens in memory, which is why there's a 50k-distinct-test cap returning `422` rather than a silent truncation — a truncated set produces confident-looking numbers computed from part of the data.

This PR also extracts the store-side WHERE builder (`internal/store/filter.go`) so the list and analytics queries interpret the filter vocabulary through the same code. That's the `-94` lines in `evidence.go`.

## Three definitions worth your attention

- **`fail_rate` excludes `ERROR` and `SKIPPED`.** An infrastructure crash is not a statement about whether the test is broken. Folding it in makes flaky infrastructure look like a failing test.
- **`flip_rate` is the separator `fail_rate` cannot provide.** A permanently broken test has `fail_rate` 1.0 and `flip_rate` 0; a flaky one has a middling fail rate and a high flip rate. Without this, the "almost always failing" list fills up with flaky tests.
- **`pass_rate_lower` is the Wilson bound.** Ranking "never fails" on the raw rate ties 8/8 with 500/500; this puts the well-evidenced record on top.

Tests carry a **list** of labels, not one category — a test can legitimately be both `flaky` and `infra_heavy`, and a precedence order would hide that. Thresholds are query parameters, echoed back in every response.

## The index was measured, and the plan's guess was wrong twice

Measured on 1M seeded rows (12 repos, 88 procedures, 70k matching a 90-day window):

| index | time | size |
|---|---|---|
| *(none — baseline)* | 450 ms | — |
| `(repo, finished_at DESC) INCLUDE (…)` ← the plan's guess | 328 ms | 155 MB |
| `(repo, procedure_ref, finished_at DESC)` | 450 ms | 79 MB — planner ignores it |
| **shipped** | **197 ms** | 149 MB, `Heap Fetches: 0` |

1. **Leading with the group key beats leading with the time column** — it supplies the `GROUP BY` and `DISTINCT ON` ordering directly, removing an external merge sort that spilled ~6 MB to disk.
2. **The `INCLUDE` is not optional** — without it the planner ignores the index and falls back to the bitmap scan, so the lean 79 MB variant buys nothing.

The `filtered` CTE projects only the group columns, so `evidence_type` is selected only when someone groups by it; selecting it unconditionally would force a heap fetch per row for everyone else.

**Worth a decision from you:** the index is ~149 MB against a 275 MB table — roughly half the table's size again. That's a real cost. Deployments not using analytics can drop it and the queries still work at 450 ms. Happy to drop it from this PR if you'd rather not pay that by default.

## Testing

- **32 unit tests**, no database: Wilson bounds verified against an independently computed reference (not just self-consistency), label boundaries at exactly the threshold, sort determinism under both directions.
- **21 integration tests** against testcontainers Postgres, on a fixture containing one test of each kind — never-failing, always-failing, flaky-by-alternation, flaky-only-by-same-commit-disagreement, error-heavy, and sparse. Every count is hand-derived, so a regression shows up as a specific wrong number.
- Verified end-to-end against the 1M-row seeded database: 83k records → 88 tests in ~225 ms including JSON.
- `bazel build //...` and `bazel test //internal/...` pass; BUILD files updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)