### PR TITLE
Add co-failure clustering and minimal test selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Base URL: `/api/v1`
 | `GET` | `/api/v1/inheritance` | List inheritance declarations |
 | `GET` | `/api/v1/analytics/summary` | Headline counts for a filter window |
 | `GET` | `/api/v1/analytics/tests` | Per-test reliability metrics (see [Analytics](#analytics)) |
+| `GET` | `/api/v1/analytics/clusters` | Co-failure clusters and the minimal covering set |
 | `GET` | `/healthz` | Health check |
 
 ### Creating evidence
@@ -415,6 +416,60 @@ Thresholds are query parameters (`min_runs`, `always_failing_rate`, `flip_rate`,
 | `group_by` | *(none)* | `evidence_type` splits a procedure into one row per harness |
 
 A query matching more than 50,000 distinct tests returns `422` rather than truncating, since a truncated set yields confident-looking numbers computed from part of the data.
+
+### Co-failure clusters and test selection
+
+`/api/v1/analytics/clusters` answers "which tests fail for the same reason, and how few of them still catch most failures".
+
+```bash
+curl "http://localhost:8000/api/v1/analytics/clusters?repo=org/repo&finished_after=2026-06-01"
+```
+
+```json
+{
+  "run_key": "auto",
+  "include_errors": false,
+  "threshold": 0.6,
+  "tests": 34,
+  "failing_runs": 96,
+  "clusters": [
+    { "id": 1, "size": 7, "covers_runs": 41, "cohesion": 0.78,
+      "members": [{ "repo": "org/repo", "procedure_ref": "//pkg/net:a_test" }] }
+  ],
+  "minimal_set": [
+    { "test": { "repo": "org/repo", "procedure_ref": "//pkg/net:a_test" },
+      "new_runs": 41, "cumulative": 41, "coverage": 0.427 }
+  ]
+}
+```
+
+**`clusters`** groups tests whose failure sets are at least `threshold` similar (Jaccard), using single-link clustering — A and C group together if each is similar to B, even if not to each other. `cohesion` is the mean pairwise similarity inside the cluster, so a long chain scores lower than a group that genuinely all fail together. Solitary tests are omitted.
+
+**`minimal_set`** is a greedy set cover, ordered so it reads as "these N tests catch X% of failing runs". Every entry contributes something no earlier entry did. It is an approximation, not a proven minimum — set cover is NP-hard, and greedy can be beaten on constructed inputs — but it is within a `ln n` factor and gives the ranked list the decision needs.
+
+#### What counts as a "run"
+
+The schema has no run column, so the grouping is derived, and clustering quality depends entirely on it:
+
+| `run_key=` | Grouping | Use when |
+|-----------|----------|----------|
+| `auto` *(default)* | `metadata.invocation_id`, falling back to the commit | Mixed sources |
+| `invocation` | `metadata.invocation_id`; rows without one are dropped | Every source sets it |
+| `commit` | `rcs_ref` | A commit is tested once |
+
+Runs are namespaced by repo, so a commit hash or invocation id reused across repos is never treated as one run.
+
+#### Errors are excluded by default
+
+`ERROR` rows are not counted as failures unless `include_errors=true`. An infrastructure outage fails every test in the same run simultaneously, which makes every pair of them look perfectly correlated — enough of those and the entire suite collapses into a single meaningless cluster that buries the real signal.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `threshold` | `0.6` | Jaccard similarity at which two tests are considered to fail together |
+| `run_key` | `auto` | See above |
+| `include_errors` | `false` | Count `ERROR` alongside `FAIL` |
+
+Queries matching more than 200,000 failing rows, 2,000 distinct failing tests, or 20,000 failing runs return `422`.
 
 ## Development
 

--- a/docs/analytics-plan.md
+++ b/docs/analytics-plan.md
@@ -188,7 +188,9 @@ A fourth nav tab, `Analytics`, with three sub-views sharing the existing filter 
 
 ## Status
 
-Phase 0 and phase 1 are implemented. Phases 2–4 are still as proposed below.
+Phases 0, 1 and 2 are implemented. Phases 3–4 are still as proposed below.
+
+One thing changed during phase 2: the plan clustered on `FAIL` **and** `ERROR`. That turned out to be wrong. An infrastructure outage errors every test in the same run at once, which makes every pair of them perfectly correlated; once outages outnumber genuine failing runs, the whole suite collapses into a single meaningless cluster. Errors are therefore excluded by default, behind `include_errors=true`. There is an integration test that reproduces the collapse.
 
 ## Implementation Phases
 

--- a/internal/analytics/BUILD.bazel
+++ b/internal/analytics/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "analytics",
     srcs = [
+        "cluster.go",
         "metrics.go",
         "stats.go",
     ],
@@ -13,6 +14,7 @@ go_library(
 go_test(
     name = "analytics_test",
     srcs = [
+        "cluster_test.go",
         "metrics_test.go",
         "stats_test.go",
     ],

--- a/internal/analytics/cluster.go
+++ b/internal/analytics/cluster.go
@@ -1,0 +1,304 @@
+package analytics
+
+import (
+	"cmp"
+	"math/bits"
+	"slices"
+)
+
+// TestID identifies a test across the analytics package.
+type TestID struct {
+	Repo         string `json:"repo"`
+	ProcedureRef string `json:"procedure_ref"`
+}
+
+func compareTestID(a, b TestID) int {
+	return cmp.Or(
+		cmp.Compare(a.ProcedureRef, b.ProcedureRef),
+		cmp.Compare(a.Repo, b.Repo),
+	)
+}
+
+// Occurrence records that a test failed in a particular run. The store produces
+// one of these per failing row; duplicates are harmless.
+type Occurrence struct {
+	Test TestID
+	Run  string
+}
+
+// Matrix is a co-failure incidence matrix: for each test, the set of runs in
+// which it failed, held as a bitset.
+//
+// Only failing rows ever enter the matrix, so it is far smaller than the
+// evidence it was derived from, and every operation below is a bitset scan
+// rather than a query.
+type Matrix struct {
+	tests []TestID
+	runs  int
+	words int
+	// bits[t] is the run set of test t, one bit per run index.
+	bits [][]uint64
+}
+
+// NewMatrix builds the incidence matrix. Tests and runs are indexed in sorted
+// order so that every result derived from the matrix is deterministic.
+func NewMatrix(occurrences []Occurrence) *Matrix {
+	testIndex := map[TestID]int{}
+	runIndex := map[string]int{}
+	var tests []TestID
+	var runs []string
+
+	for _, o := range occurrences {
+		if _, ok := testIndex[o.Test]; !ok {
+			testIndex[o.Test] = 0
+			tests = append(tests, o.Test)
+		}
+		if _, ok := runIndex[o.Run]; !ok {
+			runIndex[o.Run] = 0
+			runs = append(runs, o.Run)
+		}
+	}
+
+	slices.SortFunc(tests, compareTestID)
+	slices.Sort(runs)
+	for i, t := range tests {
+		testIndex[t] = i
+	}
+	for i, r := range runs {
+		runIndex[r] = i
+	}
+
+	m := &Matrix{
+		tests: tests,
+		runs:  len(runs),
+		words: (len(runs) + 63) / 64,
+	}
+	m.bits = make([][]uint64, len(tests))
+	for i := range m.bits {
+		m.bits[i] = make([]uint64, m.words)
+	}
+
+	for _, o := range occurrences {
+		r := runIndex[o.Run]
+		m.bits[testIndex[o.Test]][r/64] |= 1 << (r % 64)
+	}
+
+	return m
+}
+
+// Tests is the number of distinct tests that failed at least once.
+func (m *Matrix) Tests() int { return len(m.tests) }
+
+// Runs is the number of distinct runs represented.
+func (m *Matrix) Runs() int { return m.runs }
+
+// FailingRuns is the coverage denominator. Every run in the matrix contains at
+// least one failure by construction, so this equals Runs; it is named separately
+// because that is the meaning it carries in the cover results.
+func (m *Matrix) FailingRuns() int { return m.runs }
+
+// TestAt returns the test at index i.
+func (m *Matrix) TestAt(i int) TestID { return m.tests[i] }
+
+// Jaccard is the similarity of two tests' failure sets: the share of the runs
+// where either failed in which both failed. 1 means they always fail together,
+// 0 means they never do.
+func (m *Matrix) Jaccard(i, j int) float64 {
+	var intersection, union int
+	for w := range m.words {
+		a, b := m.bits[i][w], m.bits[j][w]
+		intersection += bits.OnesCount64(a & b)
+		union += bits.OnesCount64(a | b)
+	}
+	return ratio(intersection, union)
+}
+
+// Cluster is a group of tests that tend to fail together.
+type Cluster struct {
+	ID      int      `json:"id"`
+	Size    int      `json:"size"`
+	Members []TestID `json:"members"`
+	// CoversRuns is how many failing runs the cluster catches between its
+	// members — the reason to care about it.
+	CoversRuns int `json:"covers_runs"`
+	// Cohesion is the mean pairwise similarity inside the cluster. A chain
+	// linked end to end scores lower than a group that all fail together.
+	Cohesion float64 `json:"cohesion"`
+}
+
+// Cluster groups tests whose failure sets are at least `threshold` similar.
+//
+// This is single-link agglomerative clustering, done as a union-find over the
+// pairs above the threshold: A and C land in the same cluster if each is similar
+// to B, even when they are not similar to each other. That is the right shape
+// for "these fail for the same underlying reason", and it is why Cohesion is
+// reported — a long chain is a weaker claim than a tight group.
+//
+// Solitary tests are omitted: a cluster of one says nothing.
+func (m *Matrix) Cluster(threshold float64) []Cluster {
+	parent := make([]int, len(m.tests))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		for parent[x] != x {
+			parent[x] = parent[parent[x]]
+			x = parent[x]
+		}
+		return x
+	}
+
+	for i := range m.tests {
+		for j := i + 1; j < len(m.tests); j++ {
+			if m.Jaccard(i, j) >= threshold {
+				if ri, rj := find(i), find(j); ri != rj {
+					parent[ri] = rj
+				}
+			}
+		}
+	}
+
+	groups := map[int][]int{}
+	for i := range m.tests {
+		root := find(i)
+		groups[root] = append(groups[root], i)
+	}
+
+	clusters := make([]Cluster, 0, len(groups))
+	for _, members := range groups {
+		if len(members) < 2 {
+			continue
+		}
+
+		union := make([]uint64, m.words)
+		for _, i := range members {
+			for w := range m.words {
+				union[w] |= m.bits[i][w]
+			}
+		}
+		covers := 0
+		for _, w := range union {
+			covers += bits.OnesCount64(w)
+		}
+
+		var total float64
+		var pairs int
+		for a := range members {
+			for b := a + 1; b < len(members); b++ {
+				total += m.Jaccard(members[a], members[b])
+				pairs++
+			}
+		}
+
+		ids := make([]TestID, len(members))
+		for i, idx := range members {
+			ids[i] = m.tests[idx]
+		}
+		slices.SortFunc(ids, compareTestID)
+
+		clusters = append(clusters, Cluster{
+			Size:       len(ids),
+			Members:    ids,
+			CoversRuns: covers,
+			Cohesion:   ratioFloat(total, pairs),
+		})
+	}
+
+	// Most valuable first, with a deterministic tie-break.
+	slices.SortFunc(clusters, func(a, b Cluster) int {
+		return cmp.Or(
+			cmp.Compare(b.CoversRuns, a.CoversRuns),
+			compareTestID(a.Members[0], b.Members[0]),
+		)
+	})
+	for i := range clusters {
+		clusters[i].ID = i + 1
+	}
+
+	return clusters
+}
+
+// CoverStep is one entry in the minimal covering set, in the order chosen.
+type CoverStep struct {
+	Test TestID `json:"test"`
+	// NewRuns is how many failing runs this test catches that no earlier test in
+	// the list already caught. Always positive.
+	NewRuns int `json:"new_runs"`
+	// Cumulative and Coverage describe the set up to and including this step,
+	// which is what makes the list readable as "these N tests catch X%".
+	Cumulative int     `json:"cumulative"`
+	Coverage   float64 `json:"coverage"`
+}
+
+// GreedyCover selects tests in the order that catches the most failing runs
+// soonest: repeatedly take the test covering the most runs not yet covered.
+//
+// This is the classic greedy set-cover approximation. It is *not* guaranteed to
+// find the smallest possible set — set cover is NP-hard, and greedy can be beaten
+// on constructed inputs — but it is within a ln(n) factor and it produces the
+// ranked list the decision actually needs.
+//
+// Only steps that contribute are returned, so no entry in the list is redundant.
+func (m *Matrix) GreedyCover() []CoverStep {
+	steps := []CoverStep{}
+	if len(m.tests) == 0 {
+		return steps
+	}
+
+	covered := make([]uint64, m.words)
+	// Once a test contributes nothing it never can again, because the covered set
+	// only grows. Dropping it keeps later passes cheap.
+	active := make([]int, len(m.tests))
+	for i := range active {
+		active[i] = i
+	}
+
+	cumulative := 0
+	for len(active) > 0 {
+		best, bestGain := -1, 0
+		remaining := active[:0]
+
+		for _, i := range active {
+			gain := 0
+			for w := range m.words {
+				gain += bits.OnesCount64(m.bits[i][w] &^ covered[w])
+			}
+			if gain == 0 {
+				continue
+			}
+			remaining = append(remaining, i)
+			// Tests are indexed in identity order, so ">" keeps the first of any
+			// tie and the choice is reproducible.
+			if gain > bestGain {
+				best, bestGain = i, gain
+			}
+		}
+		active = remaining
+
+		if best < 0 {
+			break
+		}
+
+		for w := range m.words {
+			covered[w] |= m.bits[best][w]
+		}
+		cumulative += bestGain
+
+		steps = append(steps, CoverStep{
+			Test:       m.tests[best],
+			NewRuns:    bestGain,
+			Cumulative: cumulative,
+			Coverage:   ratio(cumulative, m.runs),
+		})
+	}
+
+	return steps
+}
+
+func ratioFloat(numerator float64, denominator int) float64 {
+	if denominator <= 0 {
+		return 0
+	}
+	return numerator / float64(denominator)
+}

--- a/internal/analytics/cluster_test.go
+++ b/internal/analytics/cluster_test.go
@@ -1,0 +1,341 @@
+package analytics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func test(name string) TestID { return TestID{Repo: "org/repo", ProcedureRef: name} }
+
+// fail builds the occurrence list from a compact "test: runs" description.
+func fail(spec map[string][]string) []Occurrence {
+	var out []Occurrence
+	for procedure, runs := range spec {
+		for _, run := range runs {
+			out = append(out, Occurrence{Test: test(procedure), Run: run})
+		}
+	}
+	return out
+}
+
+func coverNames(steps []CoverStep) []string {
+	out := make([]string, len(steps))
+	for i, s := range steps {
+		out[i] = s.Test.ProcedureRef
+	}
+	return out
+}
+
+func clusterNames(c Cluster) []string {
+	out := make([]string, len(c.Members))
+	for i, m := range c.Members {
+		out[i] = m.ProcedureRef
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Matrix and similarity
+// ---------------------------------------------------------------------------
+
+func TestMatrixCountsDistinctTestsAndRuns(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2"},
+		"//b": {"r2", "r3"},
+	}))
+
+	assert.Equal(t, 2, m.Tests())
+	assert.Equal(t, 3, m.Runs())
+}
+
+// The same test failing twice in one run is one failing run, not two.
+func TestMatrixDeduplicatesOccurrences(t *testing.T) {
+	m := NewMatrix([]Occurrence{
+		{Test: test("//a"), Run: "r1"},
+		{Test: test("//a"), Run: "r1"},
+	})
+
+	assert.Equal(t, 1, m.Tests())
+	assert.Equal(t, 1, m.Runs())
+	assert.Equal(t, 1, m.FailingRuns())
+}
+
+func TestJaccardIdenticalSetsIsOne(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2", "r3"},
+		"//b": {"r1", "r2", "r3"},
+	}))
+	assertClose(t, 1.0, m.Jaccard(0, 1))
+}
+
+func TestJaccardDisjointSetsIsZero(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2"},
+		"//b": {"r3", "r4"},
+	}))
+	assertClose(t, 0, m.Jaccard(0, 1))
+}
+
+func TestJaccardPartialOverlap(t *testing.T) {
+	// intersection {r2}, union {r1,r2,r3} -> 1/3
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2"},
+		"//b": {"r2", "r3"},
+	}))
+	assertClose(t, 1.0/3.0, m.Jaccard(0, 1))
+}
+
+func TestJaccardIsSymmetric(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2", "r5"},
+		"//b": {"r2", "r3", "r4"},
+	}))
+	assertClose(t, m.Jaccard(0, 1), m.Jaccard(1, 0))
+}
+
+// Bitsets are chunked into 64-bit words, so a set spanning several words is
+// where an off-by-one in the word arithmetic would show up.
+func TestJaccardAcrossWordBoundaries(t *testing.T) {
+	var aRuns, bRuns []string
+	for i := range 200 {
+		aRuns = append(aRuns, fmt.Sprintf("r%03d", i))
+		if i >= 100 {
+			bRuns = append(bRuns, fmt.Sprintf("r%03d", i))
+		}
+	}
+	m := NewMatrix(fail(map[string][]string{"//a": aRuns, "//b": bRuns}))
+
+	// intersection 100, union 200
+	assertClose(t, 0.5, m.Jaccard(0, 1))
+}
+
+// ---------------------------------------------------------------------------
+// Clustering
+// ---------------------------------------------------------------------------
+
+func TestClusterGroupsTestsThatFailTogether(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		// Two tests that always fail together.
+		"//net:a": {"r1", "r2", "r3"},
+		"//net:b": {"r1", "r2", "r3"},
+		// One that fails on its own.
+		"//db:c": {"r4", "r5"},
+	}))
+
+	clusters := m.Cluster(0.6)
+	require.Len(t, clusters, 1, "only the co-failing pair forms a cluster")
+	assert.ElementsMatch(t, []string{"//net:a", "//net:b"}, clusterNames(clusters[0]))
+	assert.Equal(t, 3, clusters[0].CoversRuns)
+	assertClose(t, 1.0, clusters[0].Cohesion)
+}
+
+// Single-link: a-b and b-c are each above threshold while a-c is not, and the
+// chain still forms one cluster.
+func TestClusterIsSingleLink(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2", "r3", "r4"},
+		"//b": {"r3", "r4", "r5", "r6"},
+		"//c": {"r5", "r6", "r7", "r8"},
+	}))
+
+	assert.Less(t, m.Jaccard(0, 2), 0.3, "the ends are not similar to each other")
+
+	clusters := m.Cluster(0.3)
+	require.Len(t, clusters, 1)
+	assert.Len(t, clusters[0].Members, 3)
+}
+
+func TestClusterThresholdSeparatesGroups(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2", "r3", "r4"},
+		"//b": {"r3", "r4", "r5", "r6"},
+	}))
+
+	// intersection 2, union 6 -> 1/3
+	assertClose(t, 1.0/3.0, m.Jaccard(0, 1))
+
+	assert.Len(t, m.Cluster(0.3), 1, "below the similarity, they group")
+	assert.Empty(t, m.Cluster(0.4), "above it, neither has a partner")
+}
+
+func TestClusterIgnoresSolitaryTests(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1"},
+		"//b": {"r2"},
+		"//c": {"r3"},
+	}))
+	assert.Empty(t, m.Cluster(0.5), "a cluster of one is not a cluster")
+}
+
+func TestClusterOrderingIsDeterministic(t *testing.T) {
+	spec := map[string][]string{
+		"//x:1": {"r1", "r2"}, "//x:2": {"r1", "r2"},
+		"//y:1": {"r3", "r4", "r5"}, "//y:2": {"r3", "r4", "r5"},
+	}
+
+	first := NewMatrix(fail(spec)).Cluster(0.6)
+	for range 5 {
+		again := NewMatrix(fail(spec)).Cluster(0.6)
+		require.Len(t, again, len(first))
+		for i := range first {
+			assert.Equal(t, clusterNames(first[i]), clusterNames(again[i]))
+		}
+	}
+
+	// Biggest coverage first, so the most valuable cluster leads.
+	assert.Equal(t, 3, first[0].CoversRuns)
+}
+
+// ---------------------------------------------------------------------------
+// Greedy cover
+// ---------------------------------------------------------------------------
+
+func TestGreedyCoverPicksTheBiggestContributorFirst(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//wide":   {"r1", "r2", "r3", "r4"},
+		"//narrow": {"r5"},
+	}))
+
+	steps := m.GreedyCover()
+	require.Len(t, steps, 2)
+	assert.Equal(t, "//wide", steps[0].Test.ProcedureRef)
+	assert.Equal(t, 4, steps[0].NewRuns)
+	assert.Equal(t, 4, steps[0].Cumulative)
+	assertClose(t, 0.8, steps[0].Coverage)
+
+	assert.Equal(t, 1, steps[1].NewRuns)
+	assert.Equal(t, 5, steps[1].Cumulative)
+	assertClose(t, 1.0, steps[1].Coverage)
+}
+
+// The point of the whole exercise: tests that always fail together are
+// redundant, and only one of them needs to be in the selected set.
+func TestGreedyCoverCollapsesRedundantTests(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//dup:a": {"r1", "r2", "r3"},
+		"//dup:b": {"r1", "r2", "r3"},
+		"//dup:c": {"r1", "r2", "r3"},
+		"//other": {"r4"},
+	}))
+
+	steps := m.GreedyCover()
+	require.Len(t, steps, 2, "three identical tests contribute once between them")
+	assertClose(t, 1.0, steps[len(steps)-1].Coverage)
+}
+
+func TestGreedyCoverReachesFullCoverage(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2"},
+		"//b": {"r2", "r3"},
+		"//c": {"r3", "r4"},
+		"//d": {"r9"},
+	}))
+
+	steps := m.GreedyCover()
+	require.NotEmpty(t, steps)
+
+	last := steps[len(steps)-1]
+	assert.Equal(t, m.FailingRuns(), last.Cumulative)
+	assertClose(t, 1.0, last.Coverage)
+}
+
+// Every step must add something, or the list would suggest running tests that
+// catch nothing new.
+func TestGreedyCoverStepsAlwaysContribute(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2", "r3"},
+		"//b": {"r1", "r2"},
+		"//c": {"r3"},
+		"//d": {"r1"},
+	}))
+
+	for _, s := range m.GreedyCover() {
+		assert.Positive(t, s.NewRuns, "%s adds nothing", s.Test.ProcedureRef)
+	}
+}
+
+func TestGreedyCoverCumulativeIsMonotonic(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//a": {"r1", "r2", "r3", "r4"},
+		"//b": {"r4", "r5", "r6"},
+		"//c": {"r7"},
+		"//d": {"r1", "r7"},
+	}))
+
+	steps := m.GreedyCover()
+	prev := 0
+	for _, s := range steps {
+		assert.Greater(t, s.Cumulative, prev)
+		prev = s.Cumulative
+	}
+}
+
+// Greedy is an approximation, not an optimum, and this pins that so nobody
+// reads the output as a guaranteed minimum.
+//
+// half:a and half:b partition all eight runs, so two tests suffice. The bait
+// overlaps both and is larger than either, so greedy takes it first and is then
+// left with leftovers on both sides that no single test covers — three tests to
+// do a two-test job.
+func TestGreedyCoverIsApproximateNotOptimal(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{
+		"//greedy-bait": {"r1", "r2", "r3", "r5", "r6"},
+		"//half:a":      {"r1", "r2", "r3", "r4"},
+		"//half:b":      {"r5", "r6", "r7", "r8"},
+	}))
+
+	steps := m.GreedyCover()
+	assert.Equal(t, "//greedy-bait", steps[0].Test.ProcedureRef)
+	assert.Len(t, steps, 3, "greedy needs three; half:a + half:b alone would have covered all eight")
+	assertClose(t, 1.0, steps[len(steps)-1].Coverage)
+}
+
+func TestGreedyCoverTieBreakIsDeterministic(t *testing.T) {
+	spec := map[string][]string{
+		"//c": {"r1"},
+		"//a": {"r2"},
+		"//b": {"r3"},
+	}
+
+	first := coverNames(NewMatrix(fail(spec)).GreedyCover())
+	assert.Equal(t, []string{"//a", "//b", "//c"}, first, "equal contributions break by identity")
+
+	for range 5 {
+		assert.Equal(t, first, coverNames(NewMatrix(fail(spec)).GreedyCover()))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Degenerate input
+// ---------------------------------------------------------------------------
+
+func TestEmptyMatrix(t *testing.T) {
+	m := NewMatrix(nil)
+
+	assert.Zero(t, m.Tests())
+	assert.Zero(t, m.Runs())
+	assert.Zero(t, m.FailingRuns())
+	assert.Empty(t, m.Cluster(0.5))
+	assert.Empty(t, m.GreedyCover())
+	assert.NotNil(t, m.GreedyCover(), "an empty cover is [] rather than null")
+}
+
+func TestSingleTestMatrix(t *testing.T) {
+	m := NewMatrix(fail(map[string][]string{"//only": {"r1", "r2"}}))
+
+	assert.Empty(t, m.Cluster(0.5))
+	steps := m.GreedyCover()
+	require.Len(t, steps, 1)
+	assertClose(t, 1.0, steps[0].Coverage)
+}
+
+func TestMatrixSeparatesIdenticalProceduresInDifferentRepos(t *testing.T) {
+	m := NewMatrix([]Occurrence{
+		{Test: TestID{Repo: "org/one", ProcedureRef: "//same"}, Run: "r1"},
+		{Test: TestID{Repo: "org/two", ProcedureRef: "//same"}, Run: "r1"},
+	})
+	assert.Equal(t, 2, m.Tests())
+}

--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -140,6 +140,97 @@ func (h *AnalyticsHandler) Tests(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// Clustering caps. The matrix is held in memory and the pairwise similarity is
+// quadratic in the number of tests, so both dimensions are bounded. Exceeding
+// either is reported rather than truncated: a coverage percentage computed from
+// part of the failures is worse than no answer, because it looks like an answer.
+const (
+	MaxClusterTests = 2000
+	MaxClusterRuns  = 20000
+)
+
+// DefaultClusterThreshold is the Jaccard similarity at which two tests are
+// considered to fail together.
+const DefaultClusterThreshold = 0.6
+
+// Clusters groups tests that fail together and returns the smallest set of
+// tests that still catches most failing runs.
+func (h *AnalyticsHandler) Clusters(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	filter, err := parseEvidenceFilter(q)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	runKey := store.RunKey(q.Get("run_key"))
+	if runKey == "" {
+		runKey = store.RunKeyAuto
+	}
+	if !runKey.Valid() {
+		writeError(w, http.StatusBadRequest,
+			`run_key must be one of "auto", "invocation", "commit"`)
+		return
+	}
+
+	includeErrors := q.Get("include_errors") == "true"
+
+	threshold := DefaultClusterThreshold
+	if err := parseRateParam(q, "threshold", &threshold); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	occurrences, err := h.evidence.FailureOccurrences(r.Context(), store.FailureOccurrenceParams{
+		Filter:        filter,
+		RunKey:        runKey,
+		IncludeErrors: includeErrors,
+	})
+	if err != nil {
+		var tooMany *store.ErrTooManyRows
+		if errors.As(err, &tooMany) {
+			writeError(w, http.StatusUnprocessableEntity, tooMany.Error())
+			return
+		}
+		slog.Error("failed to load failure occurrences", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	matrix := analytics.NewMatrix(occurrences)
+	if matrix.Tests() > MaxClusterTests {
+		writeError(w, http.StatusUnprocessableEntity, fmt.Sprintf(
+			"query matches %d distinct failing tests, more than the %d that can be clustered; narrow the filter or the time window",
+			matrix.Tests(), MaxClusterTests))
+		return
+	}
+	if matrix.Runs() > MaxClusterRuns {
+		writeError(w, http.StatusUnprocessableEntity, fmt.Sprintf(
+			"query matches %d failing runs, more than the %d that can be clustered; narrow the filter or the time window",
+			matrix.Runs(), MaxClusterRuns))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, struct {
+		RunKey        store.RunKey          `json:"run_key"`
+		IncludeErrors bool                  `json:"include_errors"`
+		Threshold     float64               `json:"threshold"`
+		Tests         int                   `json:"tests"`
+		FailingRuns   int                   `json:"failing_runs"`
+		Clusters      []analytics.Cluster   `json:"clusters"`
+		MinimalSet    []analytics.CoverStep `json:"minimal_set"`
+	}{
+		RunKey:        runKey,
+		IncludeErrors: includeErrors,
+		Threshold:     threshold,
+		Tests:         matrix.Tests(),
+		FailingRuns:   matrix.FailingRuns(),
+		Clusters:      matrix.Cluster(threshold),
+		MinimalSet:    matrix.GreedyCover(),
+	})
+}
+
 // Summary returns the headline counts for a filter window.
 func (h *AnalyticsHandler) Summary(w http.ResponseWriter, r *http.Request) {
 	filter, err := parseEvidenceFilter(r.URL.Query())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -62,6 +62,7 @@ func New(cfg *config.Config, pool *pgxpool.Pool) *Server {
 
 		r.Get("/analytics/summary", analyticsAPI.Summary)
 		r.Get("/analytics/tests", analyticsAPI.Tests)
+		r.Get("/analytics/clusters", analyticsAPI.Clusters)
 	})
 
 	r.Handle("/*", web.StaticHandler())

--- a/internal/store/analytics.go
+++ b/internal/store/analytics.go
@@ -180,6 +180,139 @@ LIMIT %[4]s`, cols, where, prefixed("a"), limit)
 	return stats, nil
 }
 
+// DefaultMaxFailureRows caps the failing rows one clustering request may pull
+// into memory.
+const DefaultMaxFailureRows = 200000
+
+// ErrTooManyRows is returned when a clustering query matches more failing rows
+// than the cap allows.
+type ErrTooManyRows struct {
+	Max int
+}
+
+func (e *ErrTooManyRows) Error() string {
+	return fmt.Sprintf("query matches more than %d failing rows; narrow the filter or the time window", e.Max)
+}
+
+// RunKey selects how rows are grouped into "runs" for co-failure analysis.
+// The schema has no run column, so the grouping is derived — and clustering
+// quality depends entirely on getting it right, which is why it is explicit
+// rather than assumed.
+type RunKey string
+
+const (
+	// RunKeyAuto prefers the adapter's invocation id and falls back to the
+	// commit for rows that lack one.
+	RunKeyAuto RunKey = "auto"
+	// RunKeyInvocation groups strictly by invocation id, ignoring rows without
+	// one. Correct when every source sets it.
+	RunKeyInvocation RunKey = "invocation"
+	// RunKeyCommit groups by commit. Correct when a commit is tested once.
+	RunKeyCommit RunKey = "commit"
+)
+
+// Valid reports whether k names a supported grouping.
+func (k RunKey) Valid() bool {
+	switch k {
+	case RunKeyAuto, RunKeyInvocation, RunKeyCommit:
+		return true
+	}
+	return false
+}
+
+// expr renders the run key as SQL. Fixed strings chosen by a validated enum,
+// never interpolated from caller input.
+func (k RunKey) expr() string {
+	switch k {
+	case RunKeyInvocation:
+		return "metadata->>'invocation_id'"
+	case RunKeyCommit:
+		return "rcs_ref"
+	default:
+		return "COALESCE(metadata->>'invocation_id', rcs_ref)"
+	}
+}
+
+type FailureOccurrenceParams struct {
+	Filter model.EvidenceFilter
+	RunKey RunKey
+	// IncludeErrors folds ERROR in with FAIL.
+	//
+	// Off by default, and that default matters: an infrastructure outage fails
+	// every test in the same run at once, which makes every pair of them look
+	// perfectly correlated. Including errors would collapse the whole suite into
+	// one meaningless cluster and bury the real co-failure signal.
+	IncludeErrors bool
+	// MaxRows overrides DefaultMaxFailureRows when positive.
+	MaxRows int
+}
+
+// FailureOccurrences projects the filtered failures down to (test, run) pairs,
+// which is all the co-failure analysis needs. This is a small fraction of the
+// evidence — only failing rows, only three columns, deduplicated in the database.
+func (s *EvidenceStore) FailureOccurrences(ctx context.Context, params FailureOccurrenceParams) ([]analytics.Occurrence, error) {
+	if params.RunKey == "" {
+		params.RunKey = RunKeyAuto
+	}
+	if !params.RunKey.Valid() {
+		return nil, fmt.Errorf("unknown run key %q", params.RunKey)
+	}
+
+	maxRows := params.MaxRows
+	if maxRows <= 0 {
+		maxRows = DefaultMaxFailureRows
+	}
+
+	f := buildFilter(params.Filter)
+	results := []any{model.ResultFail}
+	if params.IncludeErrors {
+		results = append(results, model.ResultError)
+	}
+	placeholders := make([]string, len(results))
+	for i, r := range results {
+		placeholders[i] = f.arg(r)
+	}
+	f.add(fmt.Sprintf("result IN (%s)", strings.Join(placeholders, ",")))
+
+	runExpr := params.RunKey.expr()
+	// Rows with no run key cannot be grouped with anything, so they are dropped
+	// rather than silently collapsed into a single null bucket.
+	f.add(runExpr + " IS NOT NULL")
+
+	query := fmt.Sprintf(
+		"SELECT DISTINCT repo, procedure_ref, %s AS run FROM evidence%s LIMIT %s",
+		runExpr, f.whereClause(), f.arg(maxRows+1))
+
+	rows, err := s.pool.Query(ctx, query, f.args...)
+	if err != nil {
+		return nil, fmt.Errorf("query failure occurrences: %w", err)
+	}
+	defer rows.Close()
+
+	occurrences := make([]analytics.Occurrence, 0)
+	for rows.Next() {
+		var repo, procedure, run string
+		if err := rows.Scan(&repo, &procedure, &run); err != nil {
+			return nil, fmt.Errorf("scan failure occurrence: %w", err)
+		}
+		occurrences = append(occurrences, analytics.Occurrence{
+			Test: analytics.TestID{Repo: repo, ProcedureRef: procedure},
+			// Runs are namespaced by repo so that two repos sharing a commit
+			// hash or invocation id are not treated as one run.
+			Run: repo + "\x00" + run,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate failure occurrences: %w", err)
+	}
+
+	if len(occurrences) > maxRows {
+		return nil, &ErrTooManyRows{Max: maxRows}
+	}
+
+	return occurrences, nil
+}
+
 // WindowSummary is the headline shape of a query window.
 type WindowSummary struct {
 	Runs    int64 `json:"runs"`

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -5,6 +5,7 @@ go_test(
     srcs = [
         "analytics_integration_test.go",
         "auth_integration_test.go",
+        "clusters_integration_test.go",
         "distinct_test.go",
         "integration_test.go",
         "list_offset_sort_test.go",

--- a/tests/clusters_integration_test.go
+++ b/tests/clusters_integration_test.go
@@ -1,0 +1,318 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nesono/evidence-store/internal/analytics"
+	"github.com/nesono/evidence-store/internal/model"
+	"github.com/nesono/evidence-store/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture
+//
+// Nineteen runs. Two tests always fail together (a shared root cause), one
+// fails independently, one never fails at all, and eight of the runs are
+// infrastructure outages that error every test at once.
+//
+// The outages deliberately outnumber the genuine failing runs, because that is
+// what turns "counting errors as failures" from mild noise into a collapse of
+// the whole suite into one cluster.
+// ---------------------------------------------------------------------------
+
+type clusterFixture struct {
+	repo string
+}
+
+func seedClusterFixture(t *testing.T) clusterFixture {
+	t.Helper()
+
+	repo := fmt.Sprintf("clusters/%d", time.Now().UnixNano())
+	var records []model.EvidenceCreate
+
+	minute := 0
+	add := func(procedure, invocation string, result model.EvidenceResult) {
+		metadata, err := json.Marshal(map[string]any{"invocation_id": invocation})
+		require.NoError(t, err)
+		records = append(records, model.EvidenceCreate{
+			Repo:         repo,
+			Branch:       "main",
+			RCSRef:       "commit-" + invocation,
+			ProcedureRef: procedure,
+			EvidenceType: "bazel",
+			Source:       "ci",
+			Result:       result,
+			FinishedAt:   model.FlexibleTime{Time: fixtureBase.Add(time.Duration(minute) * time.Minute)},
+			Metadata:     metadata,
+		})
+		minute++
+	}
+
+	// Runs 1-4: //net:a and //net:b fail together, nothing else does.
+	for i := 1; i <= 4; i++ {
+		run := fmt.Sprintf("run%02d", i)
+		add("//net:a", run, model.ResultFail)
+		add("//net:b", run, model.ResultFail)
+		add("//db:c", run, model.ResultPass)
+		add("//clean:d", run, model.ResultPass)
+	}
+
+	// Runs 5-7: //db:c fails alone.
+	for i := 5; i <= 7; i++ {
+		run := fmt.Sprintf("run%02d", i)
+		add("//net:a", run, model.ResultPass)
+		add("//net:b", run, model.ResultPass)
+		add("//db:c", run, model.ResultFail)
+		add("//clean:d", run, model.ResultPass)
+	}
+
+	// Runs 8-11: everything passes.
+	for i := 8; i <= 11; i++ {
+		run := fmt.Sprintf("run%02d", i)
+		for _, p := range []string{"//net:a", "//net:b", "//db:c", "//clean:d"} {
+			add(p, run, model.ResultPass)
+		}
+	}
+
+	// Runs 12-19: infrastructure outages. Every test errors in the same run, so
+	// counting errors as failures makes every pair look correlated. There are
+	// more outage runs than genuine failing runs, which is what turns the
+	// distortion from noise into a suite-wide collapse.
+	for i := 12; i <= 19; i++ {
+		run := fmt.Sprintf("run%02d", i)
+		for _, p := range []string{"//net:a", "//net:b", "//db:c", "//clean:d"} {
+			add(p, run, model.ResultError)
+		}
+	}
+
+	_, err := testEvidenceStore.InsertBatch(context.Background(), records)
+	require.NoError(t, err)
+
+	return clusterFixture{repo: repo}
+}
+
+type clustersResponse struct {
+	RunKey        string                `json:"run_key"`
+	IncludeErrors bool                  `json:"include_errors"`
+	Threshold     float64               `json:"threshold"`
+	Tests         int                   `json:"tests"`
+	FailingRuns   int                   `json:"failing_runs"`
+	Clusters      []analytics.Cluster   `json:"clusters"`
+	MinimalSet    []analytics.CoverStep `json:"minimal_set"`
+}
+
+func (f clusterFixture) clusters(t *testing.T, extra url.Values) clustersResponse {
+	t.Helper()
+	q := url.Values{"repo": {f.repo}}
+	for k, vs := range extra {
+		q[k] = vs
+	}
+	resp := getJSON(t, "/api/v1/analytics/clusters?"+q.Encode())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return decodeJSON[clustersResponse](t, resp)
+}
+
+func memberNames(c analytics.Cluster) []string {
+	out := make([]string, len(c.Members))
+	for i, m := range c.Members {
+		out[i] = m.ProcedureRef
+	}
+	return out
+}
+
+func coverProcedures(steps []analytics.CoverStep) []string {
+	out := make([]string, len(steps))
+	for i, s := range steps {
+		out[i] = s.Test.ProcedureRef
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+
+func TestClustersGroupsTestsThatFailTogether(t *testing.T) {
+	f := seedClusterFixture(t)
+	body := f.clusters(t, nil)
+
+	assert.Equal(t, "auto", body.RunKey)
+	assert.False(t, body.IncludeErrors)
+	assert.Equal(t, 3, body.Tests, "only tests that failed at least once")
+	assert.Equal(t, 7, body.FailingRuns, "runs 1-7")
+
+	require.Len(t, body.Clusters, 1)
+	assert.ElementsMatch(t, []string{"//net:a", "//net:b"}, memberNames(body.Clusters[0]))
+	assert.Equal(t, 4, body.Clusters[0].CoversRuns)
+	assert.InDelta(t, 1.0, body.Clusters[0].Cohesion, 1e-9)
+}
+
+// The question the issue actually asks: how few tests still catch the failures.
+func TestClustersMinimalSetCollapsesRedundancy(t *testing.T) {
+	f := seedClusterFixture(t)
+	body := f.clusters(t, nil)
+
+	// //net:a and //net:b are redundant with each other, so the cover needs one
+	// of them plus //db:c — two tests for all seven failing runs.
+	require.Len(t, body.MinimalSet, 2)
+	assert.InDelta(t, 1.0, body.MinimalSet[1].Coverage, 1e-9)
+	assert.Equal(t, 7, body.MinimalSet[1].Cumulative)
+
+	assert.Contains(t, coverProcedures(body.MinimalSet), "//db:c")
+	assert.Subset(t, []string{"//net:a", "//net:b"}, coverProcedures(body.MinimalSet)[:1])
+
+	// The bigger contributor leads.
+	assert.Equal(t, 4, body.MinimalSet[0].NewRuns)
+	assert.Equal(t, 3, body.MinimalSet[1].NewRuns)
+}
+
+// An outage errors every test in one run at once. Folding that in would make
+// every pair look perfectly correlated and collapse the suite into one
+// meaningless cluster, so ERROR is excluded unless asked for.
+func TestClustersExcludeErrorsByDefault(t *testing.T) {
+	f := seedClusterFixture(t)
+
+	byDefault := f.clusters(t, nil)
+	require.Len(t, byDefault.Clusters, 1)
+	assert.Len(t, byDefault.Clusters[0].Members, 2)
+
+	withErrors := f.clusters(t, url.Values{"include_errors": {"true"}})
+	assert.True(t, withErrors.IncludeErrors)
+	assert.Equal(t, 15, withErrors.FailingRuns, "the eight outage runs now count")
+
+	// The outages fuse the whole suite into a single cluster, including
+	// //clean:d, which never actually failed. That collapse is the reason
+	// errors are excluded by default.
+	require.Len(t, withErrors.Clusters, 1)
+	assert.ElementsMatch(t,
+		[]string{"//net:a", "//net:b", "//db:c", "//clean:d"},
+		memberNames(withErrors.Clusters[0]),
+		"counting infrastructure errors as failures makes every test look correlated with every other")
+}
+
+func TestClustersThresholdControlsGrouping(t *testing.T) {
+	f := seedClusterFixture(t)
+
+	assert.Len(t, f.clusters(t, url.Values{"threshold": {"1"}}).Clusters, 1,
+		"//net:a and //net:b are perfectly correlated, so even 1.0 groups them")
+
+	// //db:c never fails in the same run as the net pair, so nothing can join it.
+	loose := f.clusters(t, url.Values{"threshold": {"0.01"}})
+	require.Len(t, loose.Clusters, 1)
+	assert.Len(t, loose.Clusters[0].Members, 2)
+}
+
+func TestClustersRunKeySelectsGrouping(t *testing.T) {
+	f := seedClusterFixture(t)
+
+	for _, key := range []string{"auto", "invocation", "commit"} {
+		body := f.clusters(t, url.Values{"run_key": {key}})
+		assert.Equal(t, key, body.RunKey)
+		assert.Equal(t, 7, body.FailingRuns,
+			"the fixture sets one invocation per commit, so all three agree (%s)", key)
+	}
+}
+
+func TestClustersRejectsUnknownRunKey(t *testing.T) {
+	f := seedClusterFixture(t)
+	resp := getJSON(t, "/api/v1/analytics/clusters?repo="+url.QueryEscape(f.repo)+"&run_key=nonsense")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestClustersRejectsInvalidThreshold(t *testing.T) {
+	f := seedClusterFixture(t)
+	for _, v := range []string{"2", "-1", "abc"} {
+		resp := getJSON(t, "/api/v1/analytics/clusters?repo="+url.QueryEscape(f.repo)+"&threshold="+v)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, v)
+	}
+}
+
+func TestClustersRespectsEvidenceFilters(t *testing.T) {
+	f := seedClusterFixture(t)
+
+	body := f.clusters(t, url.Values{"procedure_ref": {"~^//net:"}})
+	assert.Equal(t, 2, body.Tests)
+	assert.Equal(t, 4, body.FailingRuns)
+	require.Len(t, body.MinimalSet, 1, "one of the pair covers everything they catch")
+}
+
+func TestClustersEmptyWindow(t *testing.T) {
+	resp := getJSON(t, "/api/v1/analytics/clusters?repo=clusters/does-not-exist")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeJSON[clustersResponse](t, resp)
+
+	assert.Zero(t, body.Tests)
+	assert.Zero(t, body.FailingRuns)
+	assert.Empty(t, body.Clusters)
+	assert.Empty(t, body.MinimalSet)
+	assert.NotNil(t, body.MinimalSet, "an empty cover is [] rather than null")
+}
+
+// A query too big to analyse is refused rather than truncated: a coverage
+// percentage computed from part of the failures looks exactly like an answer.
+func TestClustersRefuseOversizedQueries(t *testing.T) {
+	f := seedClusterFixture(t)
+
+	_, err := testEvidenceStore.FailureOccurrences(context.Background(), store.FailureOccurrenceParams{
+		Filter:  model.EvidenceFilter{Repo: &f.repo},
+		MaxRows: 1,
+	})
+	require.Error(t, err)
+
+	var tooMany *store.ErrTooManyRows
+	require.ErrorAs(t, err, &tooMany)
+	assert.Equal(t, 1, tooMany.Max)
+	assert.Contains(t, err.Error(), "narrow the filter")
+}
+
+func TestClustersUnderTheCapSucceed(t *testing.T) {
+	f := seedClusterFixture(t)
+
+	occurrences, err := testEvidenceStore.FailureOccurrences(context.Background(), store.FailureOccurrenceParams{
+		Filter:  model.EvidenceFilter{Repo: &f.repo},
+		MaxRows: 1000,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, analytics.NewMatrix(occurrences).Tests())
+}
+
+// Runs are namespaced by repo, so a commit hash reused across repos does not
+// fuse two unrelated runs into one.
+func TestClustersDoNotFuseRunsAcrossRepos(t *testing.T) {
+	shared := fmt.Sprintf("shared-%d", time.Now().UnixNano())
+	repoA := shared + "/a"
+	repoB := shared + "/b"
+
+	var records []model.EvidenceCreate
+	for i, repo := range []string{repoA, repoB} {
+		records = append(records, model.EvidenceCreate{
+			Repo:         repo,
+			Branch:       "main",
+			RCSRef:       "same-commit",
+			ProcedureRef: fmt.Sprintf("//p%d", i),
+			EvidenceType: "bazel",
+			Source:       "ci",
+			Result:       model.ResultFail,
+			FinishedAt:   model.FlexibleTime{Time: fixtureBase},
+		})
+	}
+	_, err := testEvidenceStore.InsertBatch(context.Background(), records)
+	require.NoError(t, err)
+
+	resp := getJSON(t, "/api/v1/analytics/clusters?repo=~^"+url.QueryEscape(shared))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeJSON[clustersResponse](t, resp)
+
+	assert.Equal(t, 2, body.Tests)
+	assert.Equal(t, 2, body.FailingRuns, "same commit hash, two different repos, two runs")
+	assert.Empty(t, body.Clusters, "they never failed in the same run")
+}


### PR DESCRIPTION
Phase 2 of `docs/analytics-plan.md`, for #58. Closes out the last of the issue's four questions: which tests fail in clusters, and how few of them still cover most failures.

Rebased on `main` (post-#63), so this is phase 2 only.

## Endpoint

```
GET /api/v1/analytics/clusters
```

Projects the filtered failures down to `(test, run)` pairs — a small fraction of the evidence — and does the rest in memory over bitsets: Jaccard similarity, single-link clustering via union-find, and a greedy set cover.

`minimal_set` is ordered so it reads as **"these N tests catch X% of failing runs"**, which is the decision you actually wanted to make. Every entry contributes runs no earlier entry did.

## Two judgement calls worth reviewing

**1. Errors are excluded from clustering by default — a change from the plan.**

The plan said cluster on `FAIL` *and* `ERROR`. That's wrong, and the failure mode is nasty: an infrastructure outage errors every test in the same run at once, making every pair look perfectly correlated. Once outages outnumber genuine failing runs, the whole suite collapses into one meaningless cluster and buries the real signal.

`include_errors=true` opts back in. `TestClustersExcludeErrorsByDefault` reproduces the collapse: with 8 outage runs against 7 genuine failing runs, all four fixture tests fuse into a single cluster — including one that never actually failed.

I found this by writing an assertion that turned out to be too strong for the original fixture, which is how the fixture ended up demonstrating the real hazard rather than a mild one.

**2. The run key is explicit, not assumed.**

The schema has no run column, so the grouping is derived — and clustering quality depends *entirely* on it. Getting it silently wrong produces plausible-looking nonsense, so it's a parameter: `auto` (invocation id, falling back to commit), `invocation`, or `commit`. Runs are namespaced by repo so a commit hash reused across repos isn't fused into one run.

If your CI mixes sources such that invocation ids and commits interleave within a repo, `commit` may be the safer default — happy to switch it.

## Greedy is an approximation, and the tests say so

Set cover is NP-hard. `TestGreedyCoverIsApproximateNotOptimal` pins an instance where greedy provably needs three tests to do a two-test job, so nobody reads the output as a minimum. (My first attempt at that test was wrong — the case I picked actually *does* reach the optimum. The one in the PR is constructed so the bait overlaps both halves and is larger than either.)

## Caps

200k failing rows, 2,000 distinct failing tests, 20,000 failing runs — all `422` rather than truncating. Pairwise similarity is quadratic in tests, and a coverage percentage computed from part of the failures looks exactly like an answer.

## Testing

- **22 unit tests**, no database: Jaccard across 64-bit word boundaries, single-link chaining where the ends aren't similar to each other, cluster/cover determinism across repeated runs, tie-breaking, and degenerate input.
- **12 integration tests** on a purpose-built fixture — two tests with a shared root cause, one independent failure, one never-failing test, and eight infrastructure outages.
- Verified on the 1M-row seeded database: ~16 ms filtered to one repo, ~137 ms unfiltered across 12 repos / 1,056 tests / 480 failing runs.
- `bazel build //...` and `bazel test //internal/...` pass.

## Still open

Phase 3 is the UI, and it needs your call on hand-rolled inline SVG vs. a CDN chart library before I start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)