### PR TITLE
Add the analytics UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,21 @@ curl "http://localhost:8000/api/v1/evidence?tags=~^nightly-"
 curl "http://localhost:8000/api/v1/evidence?notes=~device.*XYZ"
 ```
 
-**Supported fields:** `repo`, `branch`, `rcs_ref`, `evidence_type`, `source`, `procedure_ref`, `tags`, `notes`.
+**Supported fields:** `repo`, `branch`, `rcs_ref`, `ref`, `evidence_type`, `source`, `procedure_ref`, `tags`, `notes`.
+
+### Matching a branch, tag or commit with one filter
+
+`ref` matches a value against *either* identity column, so a caller who has "the thing they are looking at" does not have to say first whether it is a branch, a tag or a commit:
+
+```bash
+# Any of these work
+curl "http://localhost:8000/api/v1/analytics/tests?ref=main"
+curl "http://localhost:8000/api/v1/analytics/tests?ref=v2.0.0"
+curl "http://localhost:8000/api/v1/analytics/tests?ref=aaaa111"     # abbreviated SHA
+curl "http://localhost:8000/api/v1/analytics/tests?ref=~^release/"  # regex, both columns
+```
+
+Commits match by prefix, so a pasted short SHA finds the full one it abbreviates. Branches and tags match whole — a prefix there would answer a request for `release/1.1` with `release/1.10` as well. `ref` is available on every endpoint that takes filters, including `/api/v1/evidence`.
 
 The regex engine is [PostgreSQL POSIX regular expressions](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP) (the `~` operator). This supports the POSIX Extended Regular Expression syntax including character classes (`[a-z]`, `[[:digit:]]`), alternation (`a|b`), quantifiers (`*`, `+`, `?`, `{n,m}`), and anchors (`^`, `$`). Matching is case-sensitive.
 
@@ -370,6 +384,12 @@ The web UI's **Analytics** tab is the front end for everything below: an overvie
 of the filtered window, a sortable per-test table with presets for the four
 questions this feature exists to answer, and the co-failure clusters. Selecting a
 row opens the matching raw records in Search.
+
+The tab does not query until **Apply** is pressed — these aggregations scan far
+more evidence than a search does, so the page waits to be asked rather than
+running the widest possible query on arrival. The time range defaults to the last
+three hours and expands from there; relative ranges are resolved at query time,
+so "last 3 hours" still means the last three hours an hour later.
 
 `/api/v1/analytics/tests` collapses the evidence into one row per test — identified by `(repo, procedure_ref)` — so a suite can be judged rather than read record by record. It accepts every filter the list endpoint does, including the `~` regex and `*` prefix forms.
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,11 @@ The regex engine is [PostgreSQL POSIX regular expressions](https://www.postgresq
 
 ## Analytics
 
+The web UI's **Analytics** tab is the front end for everything below: an overview
+of the filtered window, a sortable per-test table with presets for the four
+questions this feature exists to answer, and the co-failure clusters. Selecting a
+row opens the matching raw records in Search.
+
 `/api/v1/analytics/tests` collapses the evidence into one row per test — identified by `(repo, procedure_ref)` — so a suite can be judged rather than read record by record. It accepts every filter the list endpoint does, including the `~` regex and `*` prefix forms.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -381,9 +381,13 @@ The regex engine is [PostgreSQL POSIX regular expressions](https://www.postgresq
 ## Analytics
 
 The web UI's **Analytics** tab is the front end for everything below: an overview
-of the filtered window, a sortable per-test table with presets for the four
-questions this feature exists to answer, and the co-failure clusters. Selecting a
-row opens the matching raw records in Search.
+of the filtered window, a sortable per-test table, and the co-failure clusters.
+Selecting a row opens the matching raw records in Search.
+
+Every column in the table is a sort key — click a header to rank by it, click
+again to reverse. Each of the questions this feature exists to answer is one of
+those columns, so ranking by fail rate, infra errors, flip rate or reliability is
+a single click.
 
 The tab does not query until **Apply** is pressed — these aggregations scan far
 more evidence than a search does, so the page waits to be asked rather than
@@ -431,11 +435,19 @@ Each test carries a list of labels, not one category — a test can be both flak
 
 Thresholds are query parameters (`min_runs`, `always_failing_rate`, `flip_rate`, `error_rate`, `min_errors`), because what counts as "almost always failing" is a judgement about a particular suite. The defaults are echoed back in every response.
 
+Use `label=` to *filter* by one, which is a different question from sorting. Ranking by fail rate shows the worst tests, but on a healthy suite the worst may still fail only one run in ten; `label=always_failing` returns the ones that actually meet the threshold, and `label=stable` the ones that genuinely never fail:
+
+```bash
+curl "http://localhost:8000/api/v1/analytics/tests?repo=org/repo&label=always_failing"
+curl "http://localhost:8000/api/v1/analytics/tests?repo=org/repo&label=stable&sort=pass_rate_lower&order=desc"
+```
+
 ### Other parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `sort` | `procedure_ref` | `fail_rate`, `error_rate`, `flip_rate`, `pass_rate_lower`, `runs`, `pass`, `fail`, `error`, `flaky_commits`, `last_seen`, … |
+| `label` | *(none)* | Keep only tests carrying a label: `stable`, `always_failing`, `flaky`, `infra_heavy`, `sparse` |
 | `order` | `asc` | `asc` or `desc` |
 | `limit`, `offset` | page size config | Windows the sorted set; `total` always describes the whole set |
 | `group_by` | *(none)* | `evidence_type` splits a procedure into one row per harness |

--- a/docs/analytics-plan.md
+++ b/docs/analytics-plan.md
@@ -184,11 +184,13 @@ A fourth nav tab, `Analytics`, with three sub-views sharing the existing filter 
 - **Tests** — the metrics table, sortable by every column, with label chips and quick presets that are just sort+filter combinations: *Never fails*, *Always fails*, *Most infra errors*, *Flakiest*. Clicking a row deep-links into the Search tab with `?repo=…&procedure_ref=…&result=FAIL` — the Search page already restores filters from the URL, so this needs no new plumbing.
 - **Clusters** — the cluster list, and the minimal covering set as a table with a cumulative-coverage bar.
 
-**Charts**: the page needs a sparkline and a stacked bar, nothing more. I recommend hand-rolled inline SVG (~100 lines in a small `chart.js` module) over pulling a charting library from a CDN. `index.html` does already load Pico from jsdelivr, so a CDN dependency is not unprecedented — but a full chart library is a large surface for two chart types, and inline SVG keeps the page working offline and in air-gapped deployments. Flagged as the one call worth your input before I start on phase 3.
+**Charts**: built with no new dependency, and in the end without SVG either. The two marks the page needs — a part-to-whole bar and a meter — are a flex row and a width in plain HTML/CSS, which is less code than the SVG equivalent and sidesteps viewBox scaling entirely. A charting library was never close to worth it for two shapes.
+
+Result colours reuse the app's existing status palette rather than introducing a second one, so a single page never shows two different greens. Status hues are red/green by nature and fail colour-blind separation on their own — the validated reference palette fails the same check — so every mark is paired with a written value: segments carry counts, the legend repeats them with shares, and every meter sits beside its number.
 
 ## Status
 
-Phases 0, 1 and 2 are implemented. Phases 3–4 are still as proposed below.
+Phases 0–3 are implemented. Phase 4 is still as proposed below.
 
 One thing changed during phase 2: the plan clustered on `FAIL` **and** `ERROR`. That turned out to be wrong. An infrastructure outage errors every test in the same run at once, which makes every pair of them perfectly correlated; once outages outnumber genuine failing runs, the whole suite collapses into a single meaningless cluster. Errors are therefore excluded by default, behind `include_errors=true`. There is an integration test that reproduces the collapse.
 

--- a/internal/analytics/stats.go
+++ b/internal/analytics/stats.go
@@ -49,6 +49,27 @@ func Finalize(stats []TestStats, th Thresholds) {
 	}
 }
 
+// IsLabel reports whether name is one of the labels Labels can produce.
+func IsLabel(name string) bool {
+	switch name {
+	case LabelStable, LabelAlwaysFailing, LabelFlaky, LabelInfraHeavy, LabelSparse:
+		return true
+	}
+	return false
+}
+
+// WithLabel keeps only the tests carrying the given label. The result is always
+// non-nil so an empty selection renders as [] rather than null.
+func WithLabel(stats []TestStats, label string) []TestStats {
+	kept := make([]TestStats, 0, len(stats))
+	for _, s := range stats {
+		if slices.Contains(s.Labels, label) {
+			kept = append(kept, s)
+		}
+	}
+	return kept
+}
+
 // DefaultSortKey is neutral on purpose: the endpoint answers several different
 // questions and none of them deserves to be the implicit one.
 const DefaultSortKey = "procedure_ref"

--- a/internal/analytics/stats_test.go
+++ b/internal/analytics/stats_test.go
@@ -47,6 +47,40 @@ func TestFinalizeRespectsCustomThresholds(t *testing.T) {
 	assert.Equal(t, []string{LabelSparse}, stats[0].Labels)
 }
 
+func TestIsLabel(t *testing.T) {
+	for _, l := range []string{LabelStable, LabelAlwaysFailing, LabelFlaky, LabelInfraHeavy, LabelSparse} {
+		assert.True(t, IsLabel(l), l)
+	}
+	assert.False(t, IsLabel("brittle"))
+	assert.False(t, IsLabel(""))
+}
+
+func TestWithLabel(t *testing.T) {
+	stats := []TestStats{
+		statsFor("//broken:test", Counts{Fail: 20}),
+		statsFor("//clean:test", Counts{Pass: 20}),
+		statsFor("//thin:test", Counts{Pass: 2}),
+	}
+	Finalize(stats, DefaultThresholds())
+
+	assert.Equal(t, []string{"//broken:test"},
+		procedureOrder(WithLabel(stats, LabelAlwaysFailing)))
+	assert.Equal(t, []string{"//clean:test"},
+		procedureOrder(WithLabel(stats, LabelStable)))
+	assert.Equal(t, []string{"//thin:test"},
+		procedureOrder(WithLabel(stats, LabelSparse)))
+}
+
+// Filtering by a label nothing carries is an empty table, not a null one.
+func TestWithLabelMatchingNothing(t *testing.T) {
+	stats := []TestStats{statsFor("//clean:test", Counts{Pass: 20})}
+	Finalize(stats, DefaultThresholds())
+
+	got := WithLabel(stats, LabelInfraHeavy)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
 func TestSortByFailRate(t *testing.T) {
 	stats := []TestStats{
 		statsFor("//low:test", Counts{Pass: 19, Fail: 1}),

--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -105,6 +105,19 @@ func (h *AnalyticsHandler) Tests(w http.ResponseWriter, r *http.Request) {
 	}
 
 	analytics.Finalize(stats, thresholds)
+
+	// Labels are derived, not stored, so filtering by one happens here rather
+	// than in SQL. This is the honest way to ask "which tests always fail":
+	// ranking by fail rate only shows the worst, which on a healthy suite is
+	// still nowhere near always.
+	if label := q.Get("label"); label != "" {
+		if !analytics.IsLabel(label) {
+			writeError(w, http.StatusBadRequest, "unknown label "+label)
+			return
+		}
+		stats = analytics.WithLabel(stats, label)
+	}
+
 	if err := analytics.Sort(stats, sortKey, desc); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/api/filter.go
+++ b/internal/api/filter.go
@@ -27,6 +27,9 @@ func parseEvidenceFilter(q url.Values) (model.EvidenceFilter, error) {
 	if v := q.Get("branch"); v != "" {
 		filter.Branch = &v
 	}
+	if v := q.Get("ref"); v != "" {
+		filter.Ref = &v
+	}
 	if v := q.Get("evidence_type"); v != "" {
 		filter.EvidenceType = &v
 	}

--- a/internal/api/filter_test.go
+++ b/internal/api/filter_test.go
@@ -65,6 +65,26 @@ func TestParseEvidenceFilterEmptyValuesAreUnset(t *testing.T) {
 	assert.Nil(t, f.Notes)
 }
 
+func TestParseEvidenceFilterRef(t *testing.T) {
+	f, err := parseEvidenceFilter(mustQuery(t, "ref=release%2F1.2"))
+	require.NoError(t, err)
+	require.NotNil(t, f.Ref)
+	assert.Equal(t, "release/1.2", *f.Ref)
+
+	// ref is its own filter, not a substitute for branch or rcs_ref.
+	assert.Nil(t, f.Branch)
+	assert.Nil(t, f.RCSRef)
+}
+
+func TestParseEvidenceFilterRefCombinesWithBranch(t *testing.T) {
+	f, err := parseEvidenceFilter(mustQuery(t, "ref=abc123&branch=main"))
+	require.NoError(t, err)
+	require.NotNil(t, f.Ref)
+	require.NotNil(t, f.Branch)
+	assert.Equal(t, "abc123", *f.Ref)
+	assert.Equal(t, "main", *f.Branch)
+}
+
 func TestParseEvidenceFilterResults(t *testing.T) {
 	f, err := parseEvidenceFilter(mustQuery(t, "result=PASS,FAIL"))
 	require.NoError(t, err)

--- a/internal/model/evidence.go
+++ b/internal/model/evidence.go
@@ -109,9 +109,13 @@ type EvidenceResponse struct {
 }
 
 type EvidenceFilter struct {
-	Repo           *string
-	RCSRef         *string
-	Branch         *string
+	Repo   *string
+	RCSRef *string
+	Branch *string
+	// Ref matches a branch, tag or commit with one value. The UI offers a single
+	// box because a user pasting "what they are looking at" does not want to
+	// first classify it.
+	Ref            *string
 	EvidenceType   *string
 	Result         []EvidenceResult
 	Source         *string

--- a/internal/store/filter.go
+++ b/internal/store/filter.go
@@ -76,6 +76,22 @@ func buildFilter(filter model.EvidenceFilter) *sqlFilter {
 		}
 	}
 
+	// A single value matched against either identity column. Commits get prefix
+	// matching so a pasted short SHA finds the full one it abbreviates; branches
+	// and tags are matched whole, since a prefix there would quietly pull in
+	// release/1.10 when the user asked for release/1.1.
+	if v := filter.Ref; v != nil {
+		val := *v
+		if strings.HasPrefix(val, "~") {
+			pattern := f.arg(val[1:])
+			f.add(fmt.Sprintf("(branch ~ %[1]s OR rcs_ref ~ %[1]s)", pattern))
+		} else {
+			exact := f.arg(val)
+			prefix := f.arg(val + "%")
+			f.add(fmt.Sprintf("(branch = %s OR rcs_ref LIKE %s)", exact, prefix))
+		}
+	}
+
 	if len(filter.Result) > 0 {
 		placeholders := make([]string, len(filter.Result))
 		for i, r := range filter.Result {

--- a/tests/analytics_integration_test.go
+++ b/tests/analytics_integration_test.go
@@ -408,3 +408,92 @@ func TestAnalyticsSummaryEmptyWindow(t *testing.T) {
 	assert.Zero(t, body.Tests)
 	assert.InDelta(t, 0, body.FailRate, 1e-9)
 }
+
+// ---------------------------------------------------------------------------
+// Combined ref filter
+//
+// One box in the UI has to match whatever the user pasted, without asking them
+// to say first whether it is a branch, a tag or a commit.
+// ---------------------------------------------------------------------------
+
+func seedRefFixture(t *testing.T) string {
+	t.Helper()
+
+	repo := fmt.Sprintf("refs/%d", time.Now().UnixNano())
+	rec := func(branch, rcsRef, procedure string) model.EvidenceCreate {
+		return model.EvidenceCreate{
+			Repo:         repo,
+			Branch:       branch,
+			RCSRef:       rcsRef,
+			ProcedureRef: procedure,
+			EvidenceType: "bazel",
+			Source:       "ci",
+			Result:       model.ResultPass,
+			FinishedAt:   model.FlexibleTime{Time: fixtureBase},
+		}
+	}
+
+	_, err := testEvidenceStore.InsertBatch(context.Background(), []model.EvidenceCreate{
+		rec("main", "aaaa1111bbbb2222cccc3333dddd4444eeee5555", "//on:main"),
+		rec("release/1.1", "1111aaaa2222bbbb3333cccc4444dddd5555eeee", "//on:release11"),
+		rec("release/1.10", "9999aaaa8888bbbb7777cccc6666dddd5555eeee", "//on:release110"),
+		rec("feature/x", "v2.0.0", "//on:tag"),
+	})
+	require.NoError(t, err)
+	return repo
+}
+
+func refProcedures(t *testing.T, repo, ref string) []string {
+	t.Helper()
+	q := url.Values{"repo": {repo}, "ref": {ref}, "min_runs": {"1"}}
+	resp := getJSON(t, "/api/v1/analytics/tests?"+q.Encode())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeJSON[analyticsTestsResponse](t, resp)
+
+	out := make([]string, 0, len(body.Tests))
+	for _, s := range body.Tests {
+		out = append(out, s.ProcedureRef)
+	}
+	return out
+}
+
+func TestRefFilterMatchesBranch(t *testing.T) {
+	repo := seedRefFixture(t)
+	assert.Equal(t, []string{"//on:main"}, refProcedures(t, repo, "main"))
+}
+
+func TestRefFilterMatchesFullCommit(t *testing.T) {
+	repo := seedRefFixture(t)
+	assert.Equal(t, []string{"//on:main"},
+		refProcedures(t, repo, "aaaa1111bbbb2222cccc3333dddd4444eeee5555"))
+}
+
+// Pasting an abbreviated SHA is the common case and has to find the full one.
+func TestRefFilterMatchesAbbreviatedCommit(t *testing.T) {
+	repo := seedRefFixture(t)
+	assert.Equal(t, []string{"//on:main"}, refProcedures(t, repo, "aaaa111"))
+}
+
+func TestRefFilterMatchesTagStoredAsRef(t *testing.T) {
+	repo := seedRefFixture(t)
+	assert.Equal(t, []string{"//on:tag"}, refProcedures(t, repo, "v2.0.0"))
+}
+
+// Branches are matched whole. Prefix matching there would answer a request for
+// release/1.1 with release/1.10 as well.
+func TestRefFilterDoesNotPrefixMatchBranches(t *testing.T) {
+	repo := seedRefFixture(t)
+	assert.Equal(t, []string{"//on:release11"}, refProcedures(t, repo, "release/1.1"))
+}
+
+func TestRefFilterAcceptsRegex(t *testing.T) {
+	repo := seedRefFixture(t)
+	assert.ElementsMatch(t,
+		[]string{"//on:release11", "//on:release110"},
+		refProcedures(t, repo, "~^release/"))
+}
+
+func TestRefFilterMatchingNothingReturnsEmpty(t *testing.T) {
+	repo := seedRefFixture(t)
+	assert.Empty(t, refProcedures(t, repo, "no-such-ref"))
+}

--- a/tests/analytics_integration_test.go
+++ b/tests/analytics_integration_test.go
@@ -497,3 +497,61 @@ func TestRefFilterMatchingNothingReturnsEmpty(t *testing.T) {
 	repo := seedRefFixture(t)
 	assert.Empty(t, refProcedures(t, repo, "no-such-ref"))
 }
+
+// ---------------------------------------------------------------------------
+// Label filtering
+//
+// Ranking by fail rate answers "which are worst"; only a label answers "which
+// always fail", because on a healthy suite the worst is nowhere near always.
+// ---------------------------------------------------------------------------
+
+func labelledProcedures(t *testing.T, f analyticsFixture, label string) []string {
+	t.Helper()
+	body := f.get(t, url.Values{"label": {label}})
+
+	out := make([]string, 0, len(body.Tests))
+	for _, s := range body.Tests {
+		out = append(out, s.ProcedureRef)
+	}
+	return out
+}
+
+func TestAnalyticsFilterByAlwaysFailingLabel(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	assert.Equal(t, []string{"//broken:test"}, labelledProcedures(t, f, analytics.LabelAlwaysFailing))
+}
+
+func TestAnalyticsFilterByStableLabel(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	assert.Equal(t, []string{"//stable:test"}, labelledProcedures(t, f, analytics.LabelStable))
+}
+
+func TestAnalyticsFilterByFlakyLabel(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	assert.ElementsMatch(t,
+		[]string{"//flaky:test", "//disagree:test"},
+		labelledProcedures(t, f, analytics.LabelFlaky))
+}
+
+func TestAnalyticsFilterByInfraHeavyLabel(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	assert.Equal(t, []string{"//infra:test"}, labelledProcedures(t, f, analytics.LabelInfraHeavy))
+}
+
+// The total has to describe the filtered set, or paging through it lies.
+func TestAnalyticsLabelFilterNarrowsTheTotal(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+
+	all := f.get(t, nil)
+	assert.Equal(t, 6, all.Total)
+
+	filtered := f.get(t, url.Values{"label": {analytics.LabelAlwaysFailing}})
+	assert.Equal(t, 1, filtered.Total)
+}
+
+func TestAnalyticsRejectsUnknownLabel(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	resp := getJSON(t, "/api/v1/analytics/tests?repo="+url.QueryEscape(f.repo)+"&label=brittle")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/web/static/analytics.js
+++ b/web/static/analytics.js
@@ -29,6 +29,9 @@ const RANGES = {
 
 const DEFAULT_RANGE = "3h";
 
+// Mirrors the server's default, used when the threshold box cannot be read.
+const DEFAULT_CLUSTER_THRESHOLD = 0.6;
+
 // Ranked answers to the questions the analytics page exists to ask. Each is
 // just a sort key — the table is one view, not four.
 const PRESETS = {
@@ -395,8 +398,15 @@ async function loadClusters() {
   loading("an-clusters");
 
   const controls = document.getElementById("analytics-cluster-controls");
+  // A number input reports "" when the browser considers the typed value
+  // invalid, which a locale using a decimal comma can trigger. Fall back rather
+  // than sending nothing and silently getting a different threshold than the
+  // one on screen.
+  const typed = parseFloat(controls.elements.threshold.value);
+  const threshold = Number.isFinite(typed) ? typed : DEFAULT_CLUSTER_THRESHOLD;
+
   const data = await getJSON("/analytics/clusters", query({
-    threshold: controls.elements.threshold.value,
+    threshold,
     run_key: controls.elements.run_key.value,
     include_errors: controls.elements.include_errors.checked ? "true" : "",
   }));

--- a/web/static/analytics.js
+++ b/web/static/analytics.js
@@ -32,15 +32,6 @@ const DEFAULT_RANGE = "3h";
 // Mirrors the server's default, used when the threshold box cannot be read.
 const DEFAULT_CLUSTER_THRESHOLD = 0.6;
 
-// Ranked answers to the questions the analytics page exists to ask. Each is
-// just a sort key — the table is one view, not four.
-const PRESETS = {
-  flakiest: { label: "Flakiest", sort: "flip_rate", desc: true },
-  never_fails: { label: "Never fails", sort: "pass_rate_lower", desc: true },
-  always_fails: { label: "Always fails", sort: "fail_rate", desc: true },
-  infra: { label: "Most infra errors", sort: "error_rate", desc: true },
-};
-
 const LABEL_TEXT = {
   stable: "Stable",
   always_failing: "Always failing",
@@ -267,23 +258,56 @@ async function loadOverview() {
 
 // --- Tests ---
 
+// Each question the analytics page exists to answer is one of these columns,
+// so ranking by it is a click on its header. `desc` is the direction a column
+// starts in — the interesting end for a rate is the high one, but for a name
+// it is A first.
 const COLUMNS = [
-  { key: "procedure_ref", label: "Test", sortable: true, cls: "an-col-test" },
+  {
+    key: "procedure_ref", label: "Test", desc: false, cls: "an-col-test",
+    hint: "Sort by test name",
+  },
   { key: null, label: "Labels", cls: "an-col-labels" },
-  { key: "runs", label: "Runs", sortable: true, cls: "an-col-num" },
-  { key: "fail_rate", label: "Fail rate", sortable: true, cls: "an-col-rate" },
-  { key: "error_rate", label: "Infra errors", sortable: true, cls: "an-col-rate" },
-  { key: "flip_rate", label: "Flip rate", sortable: true, cls: "an-col-rate" },
-  { key: "last_seen", label: "Last seen", sortable: true, cls: "an-col-time" },
+  {
+    key: "runs", label: "Runs", desc: true, cls: "an-col-num",
+    hint: "Sort by how many times the test ran",
+  },
+  {
+    key: "fail_rate", label: "Fail rate", desc: true, cls: "an-col-rate",
+    hint: "Share of verdicts that failed. Sort descending for the chronically broken.",
+  },
+  {
+    key: "error_rate", label: "Infra errors", desc: true, cls: "an-col-rate",
+    hint: "Share of runs lost to infrastructure rather than a verdict.",
+  },
+  {
+    key: "flip_rate", label: "Flip rate", desc: true, cls: "an-col-rate",
+    hint: "How often consecutive runs changed verdict. Sort descending for the flakiest.",
+  },
+  {
+    key: "pass_rate_lower", label: "Reliability", desc: true, cls: "an-col-rate",
+    hint: "Wilson 95% lower bound on the pass rate. Sort descending for tests that never "
+        + "fail, best-evidenced first — a clean 500-run record outranks a clean 8-run one.",
+  },
+  {
+    key: "last_seen", label: "Last seen", desc: true, cls: "an-col-time",
+    hint: "Sort by when the test last ran",
+  },
 ];
+
+function columnFor(key) {
+  return COLUMNS.find(c => c.key === key);
+}
 
 function headerHTML() {
   return COLUMNS.map(c => {
-    if (!c.sortable) return `<th class="${c.cls}">${esc(c.label)}</th>`;
+    if (!c.key) return `<th class="${c.cls}">${esc(c.label)}</th>`;
     const active = c.key === sortKey;
     const arrow = active ? (sortDesc ? " ▾" : " ▴") : "";
     return `<th class="${c.cls} an-sortable${active ? " an-sorted" : ""}"
-                data-sort="${c.key}">${esc(c.label)}${arrow}</th>`;
+                data-sort="${c.key}" title="${esc(c.hint)}"
+                aria-sort="${active ? (sortDesc ? "descending" : "ascending") : "none"}"
+                >${esc(c.label)}${arrow}</th>`;
   }).join("");
 }
 
@@ -300,6 +324,7 @@ function testRowHTML(t) {
       <td class="an-col-rate">${rateCell(t.fail_rate, "fail", sortKey === "fail_rate")}</td>
       <td class="an-col-rate">${rateCell(t.error_rate, "error", sortKey === "error_rate")}</td>
       <td class="an-col-rate">${rateCell(t.flip_rate, "flip", sortKey === "flip_rate")}</td>
+      <td class="an-col-rate">${rateCell(t.pass_rate_lower, "reliability", sortKey === "pass_rate_lower")}</td>
       <td class="an-col-time">${formatTime(t.last_seen)}</td>
     </tr>`;
 }
@@ -307,6 +332,7 @@ function testRowHTML(t) {
 async function loadTests() {
   loading("an-tests-body-wrap");
   const data = await getJSON("/analytics/tests", query({
+    label: document.getElementById("an-label")?.value,
     sort: sortKey,
     order: sortDesc ? "desc" : "asc",
     limit: PAGE_SIZE,
@@ -336,10 +362,10 @@ async function loadTests() {
   document.querySelectorAll("#an-tests-body-wrap .an-sortable").forEach(th => {
     th.addEventListener("click", () => {
       const key = th.dataset.sort;
-      // Re-clicking the active column flips it; a new column starts descending,
-      // which is the interesting end for every rate here.
+      // Re-clicking the active column flips it; a new column opens in whichever
+      // direction is the interesting one for that column.
       if (key === sortKey) sortDesc = !sortDesc;
-      else { sortKey = key; sortDesc = true; }
+      else { sortKey = key; sortDesc = columnFor(key).desc; }
       offset = 0;
       refresh();
     });
@@ -526,19 +552,6 @@ document.getElementById("an-clear")?.addEventListener("click", () => {
 document.getElementById("an-views")?.addEventListener("click", e => {
   const btn = e.target.closest("button[data-view]");
   if (btn) setView(btn.dataset.view);
-});
-
-document.getElementById("an-presets")?.addEventListener("click", e => {
-  const btn = e.target.closest("button[data-preset]");
-  if (!btn) return;
-  const preset = PRESETS[btn.dataset.preset];
-  sortKey = preset.sort;
-  sortDesc = preset.desc;
-  offset = 0;
-  document.querySelectorAll("#an-presets button").forEach(b => {
-    b.classList.toggle("active", b === btn);
-  });
-  refresh();
 });
 
 document.getElementById("an-prev")?.addEventListener("click", () => {

--- a/web/static/analytics.js
+++ b/web/static/analytics.js
@@ -1,0 +1,484 @@
+// The Analytics view: three sub-views over /api/v1/analytics/*.
+//
+// Marks are plain HTML/CSS rather than SVG or a charting library. The page has
+// no build step, and the shapes needed here — a stacked part-to-whole bar and a
+// row of meters — are a flex box and a width each. That keeps the page working
+// offline with nothing to vendor, and sidesteps viewBox scaling entirely.
+//
+// Result colours are the app's status palette, and they never carry meaning on
+// their own: every segment and every meter is accompanied by a written value or
+// a legend entry.
+
+import { API_BASE, apiFetch, esc, formatTime } from "./common.js";
+
+const FILTER_FIELDS = ["repo", "branch", "finished_after", "finished_before"];
+
+// Ranked answers to the questions the analytics page exists to ask. Each is
+// just a sort key — the table is one view, not four.
+const PRESETS = {
+  flakiest: { label: "Flakiest", sort: "flip_rate", desc: true },
+  never_fails: { label: "Never fails", sort: "pass_rate_lower", desc: true },
+  always_fails: { label: "Always fails", sort: "fail_rate", desc: true },
+  infra: { label: "Most infra errors", sort: "error_rate", desc: true },
+};
+
+const LABEL_TEXT = {
+  stable: "Stable",
+  always_failing: "Always failing",
+  flaky: "Flaky",
+  infra_heavy: "Infra-heavy",
+  sparse: "Sparse",
+};
+
+const PAGE_SIZE = 50;
+
+let loaded = false;
+let view = "overview";
+let sortKey = "fail_rate";
+let sortDesc = true;
+let offset = 0;
+let total = 0;
+
+// --- Helpers ---
+
+function pct(v, digits = 1) {
+  return `${(v * 100).toFixed(digits)}%`;
+}
+
+function num(n) {
+  return n.toLocaleString("en-US");
+}
+
+function readFilters() {
+  const form = document.getElementById("analytics-filter");
+  const filters = {};
+  for (const field of FILTER_FIELDS) {
+    const value = form.elements[field]?.value.trim();
+    if (value) filters[field] = value;
+  }
+  return filters;
+}
+
+function query(extra = {}) {
+  const params = new URLSearchParams(readFilters());
+  for (const [k, v] of Object.entries(extra)) {
+    if (v !== undefined && v !== null && v !== "") params.set(k, v);
+  }
+  return params;
+}
+
+async function getJSON(path, params) {
+  const resp = await apiFetch(`${API_BASE}${path}?${params}`);
+  const body = await resp.json();
+  if (!resp.ok) {
+    throw new Error(body.error || `request failed (${resp.status})`);
+  }
+  return body;
+}
+
+function showError(message) {
+  const box = document.getElementById("an-error");
+  box.textContent = message;
+  box.hidden = false;
+}
+
+function clearError() {
+  document.getElementById("an-error").hidden = true;
+}
+
+function loading(containerId, message = "Loading...") {
+  document.getElementById(containerId).innerHTML =
+    `<p class="empty-state">${esc(message)}</p>`;
+}
+
+// --- Marks ---
+
+const RESULT_ORDER = ["pass", "fail", "error", "skipped"];
+
+// A part-to-whole bar. Segments are flex-grown by count, so the bar is exact at
+// any width without measuring anything. Every segment is also written out in the
+// legend below, so the colours are never the only carrier of meaning.
+function stackedResultBar(counts) {
+  const totalRuns = RESULT_ORDER.reduce((sum, k) => sum + (counts[k] || 0), 0);
+  if (totalRuns === 0) return `<p class="empty-state">No records in this window</p>`;
+
+  const segments = RESULT_ORDER
+    .filter(k => counts[k] > 0)
+    .map(k => {
+      const share = counts[k] / totalRuns;
+      return `<div class="an-seg an-seg-${k}" style="flex-grow:${counts[k]}"
+                   title="${k.toUpperCase()}: ${num(counts[k])} (${pct(share)})">
+                <span class="an-seg-label">${num(counts[k])}</span>
+              </div>`;
+    }).join("");
+
+  const legend = RESULT_ORDER.map(k => `
+    <li class="an-legend-item">
+      <span class="an-swatch an-seg-${k}" aria-hidden="true"></span>
+      <span class="an-legend-name">${k.toUpperCase()}</span>
+      <span class="an-legend-value">${num(counts[k] || 0)}</span>
+      <span class="an-legend-share">${pct((counts[k] || 0) / totalRuns)}</span>
+    </li>`).join("");
+
+  return `
+    <div class="an-stack" role="img"
+         aria-label="Result distribution: ${RESULT_ORDER.map(k => `${k} ${counts[k] || 0}`).join(", ")}">
+      ${segments}
+    </div>
+    <ul class="an-legend">${legend}</ul>`;
+}
+
+// A rate as a length plus its written value. The number is always present, so
+// the bar is a fast comparison aid rather than the only way to read the cell.
+function meter(rate, kind) {
+  const width = Math.max(0, Math.min(1, rate)) * 100;
+  return `
+    <div class="an-meter-cell">
+      <div class="an-meter" title="${pct(rate, 1)}">
+        <div class="an-meter-fill an-meter-${kind}" style="width:${width}%"></div>
+      </div>
+      <span class="an-num">${pct(rate, 1)}</span>
+    </div>`;
+}
+
+// Only the column being sorted on is drawn as a meter. A bar in every rate cell
+// is three little charts per row competing for attention; a bar in the column the
+// reader chose to rank by is the comparison they actually asked for. The other
+// cells keep their numbers, so nothing is lost.
+function rateCell(rate, kind, emphasised) {
+  if (!emphasised) return `<span class="an-num an-num-plain">${pct(rate, 1)}</span>`;
+  const width = Math.max(0, Math.min(1, rate)) * 100;
+  return `
+    <div class="an-rate" title="${pct(rate, 1)}">
+      <span class="an-num">${pct(rate, 1)}</span>
+      <div class="an-meter">
+        <div class="an-meter-fill an-meter-${kind}" style="width:${width}%"></div>
+      </div>
+    </div>`;
+}
+
+function statTile(label, value, hint) {
+  return `
+    <div class="an-tile">
+      <div class="an-tile-value">${value}</div>
+      <div class="an-tile-label">${esc(label)}</div>
+      ${hint ? `<div class="an-tile-hint">${esc(hint)}</div>` : ""}
+    </div>`;
+}
+
+function labelChips(labels) {
+  if (!labels || labels.length === 0) return `<span class="an-muted">—</span>`;
+  return labels
+    .map(l => `<span class="an-chip an-chip-${l}">${esc(LABEL_TEXT[l] || l)}</span>`)
+    .join(" ");
+}
+
+// --- Overview ---
+
+async function loadOverview() {
+  loading("an-overview");
+  const data = await getJSON("/analytics/summary", query());
+
+  const counts = {
+    pass: data.pass, fail: data.fail, error: data.error, skipped: data.skipped,
+  };
+  const passRate = data.runs > 0 ? data.pass / data.runs : 0;
+
+  const span = data.first_seen && data.last_seen
+    ? `${formatTime(data.first_seen)} — ${formatTime(data.last_seen)} UTC`
+    : "no records in this window";
+
+  document.getElementById("an-overview").innerHTML = `
+    <div class="an-hero">
+      <div class="an-hero-value">${pct(passRate)}</div>
+      <div class="an-hero-label">of ${num(data.runs)} runs passed</div>
+      <div class="an-hero-span">${esc(span)}</div>
+    </div>
+
+    <div class="an-tiles">
+      ${statTile("Tests", num(data.tests))}
+      ${statTile("Commits", num(data.commits))}
+      ${statTile("Repos", num(data.repos))}
+      ${statTile("Fail rate", pct(data.fail_rate), "of PASS + FAIL")}
+      ${statTile("Infra error rate", pct(data.error_rate), "of executed runs")}
+    </div>
+
+    <h5 class="an-section-title">Result distribution</h5>
+    ${stackedResultBar(counts)}`;
+}
+
+// --- Tests ---
+
+const COLUMNS = [
+  { key: "procedure_ref", label: "Test", sortable: true, cls: "an-col-test" },
+  { key: null, label: "Labels", cls: "an-col-labels" },
+  { key: "runs", label: "Runs", sortable: true, cls: "an-col-num" },
+  { key: "fail_rate", label: "Fail rate", sortable: true, cls: "an-col-rate" },
+  { key: "error_rate", label: "Infra errors", sortable: true, cls: "an-col-rate" },
+  { key: "flip_rate", label: "Flip rate", sortable: true, cls: "an-col-rate" },
+  { key: "last_seen", label: "Last seen", sortable: true, cls: "an-col-time" },
+];
+
+function headerHTML() {
+  return COLUMNS.map(c => {
+    if (!c.sortable) return `<th class="${c.cls}">${esc(c.label)}</th>`;
+    const active = c.key === sortKey;
+    const arrow = active ? (sortDesc ? " ▾" : " ▴") : "";
+    return `<th class="${c.cls} an-sortable${active ? " an-sorted" : ""}"
+                data-sort="${c.key}">${esc(c.label)}${arrow}</th>`;
+  }).join("");
+}
+
+function testRowHTML(t) {
+  return `
+    <tr data-repo="${esc(t.repo)}" data-procedure="${esc(t.procedure_ref)}"
+        title="Show the matching records in Search">
+      <td class="an-col-test">
+        <span class="an-test-name">${esc(t.procedure_ref)}</span>
+        <span class="an-test-repo">${esc(t.repo)}</span>
+      </td>
+      <td class="an-col-labels">${labelChips(t.labels)}</td>
+      <td class="an-col-num">${num(t.runs)}</td>
+      <td class="an-col-rate">${rateCell(t.fail_rate, "fail", sortKey === "fail_rate")}</td>
+      <td class="an-col-rate">${rateCell(t.error_rate, "error", sortKey === "error_rate")}</td>
+      <td class="an-col-rate">${rateCell(t.flip_rate, "flip", sortKey === "flip_rate")}</td>
+      <td class="an-col-time">${formatTime(t.last_seen)}</td>
+    </tr>`;
+}
+
+async function loadTests() {
+  loading("an-tests-body-wrap");
+  const data = await getJSON("/analytics/tests", query({
+    sort: sortKey,
+    order: sortDesc ? "desc" : "asc",
+    limit: PAGE_SIZE,
+    offset,
+  }));
+
+  total = data.total;
+
+  const rows = data.tests.length
+    ? data.tests.map(testRowHTML).join("")
+    : `<tr><td colspan="${COLUMNS.length}" class="empty-state">No tests match these filters</td></tr>`;
+
+  document.getElementById("an-tests-body-wrap").innerHTML = `
+    <table class="an-table">
+      <thead><tr>${headerHTML()}</tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+
+  const shown = data.tests.length;
+  document.getElementById("an-tests-range").textContent = total === 0
+    ? "No tests"
+    : `${num(offset + 1)}–${num(offset + shown)} of ${num(total)} tests`;
+
+  document.getElementById("an-prev").disabled = offset === 0;
+  document.getElementById("an-next").disabled = offset + shown >= total;
+
+  document.querySelectorAll("#an-tests-body-wrap .an-sortable").forEach(th => {
+    th.addEventListener("click", () => {
+      const key = th.dataset.sort;
+      // Re-clicking the active column flips it; a new column starts descending,
+      // which is the interesting end for every rate here.
+      if (key === sortKey) sortDesc = !sortDesc;
+      else { sortKey = key; sortDesc = true; }
+      offset = 0;
+      refresh();
+    });
+  });
+
+  // Drilling into the raw records is a link into the Search view, which already
+  // restores its filters from the URL — so this needs no plumbing on that side.
+  document.querySelectorAll("#an-tests-body-wrap tbody tr[data-procedure]").forEach(tr => {
+    tr.addEventListener("click", () => {
+      const params = new URLSearchParams({
+        repo: tr.dataset.repo,
+        procedure_ref: tr.dataset.procedure,
+      });
+      const filters = readFilters();
+      if (filters.finished_after) params.set("finished_after", filters.finished_after);
+      if (filters.finished_before) params.set("finished_before", filters.finished_before);
+      window.location.search = params.toString();
+    });
+  });
+}
+
+// --- Clusters ---
+
+function clusterCard(c) {
+  const members = c.members
+    .map(m => `<li title="${esc(m.repo)}">${esc(m.procedure_ref)}</li>`)
+    .join("");
+  return `
+    <div class="an-cluster">
+      <header class="an-cluster-head">
+        <span class="an-cluster-title">Cluster ${c.id}</span>
+        <span class="an-cluster-stat">${c.size} tests</span>
+        <span class="an-cluster-stat">${num(c.covers_runs)} failing runs</span>
+        <span class="an-cluster-stat" title="Mean pairwise similarity — a chain scores lower than a group that all fail together">
+          cohesion ${c.cohesion.toFixed(2)}
+        </span>
+      </header>
+      <ul class="an-cluster-members">${members}</ul>
+    </div>`;
+}
+
+function coverRowHTML(step, index) {
+  return `
+    <tr>
+      <td class="an-col-num">${index + 1}</td>
+      <td class="an-col-test">
+        <span class="an-test-name">${esc(step.test.procedure_ref)}</span>
+        <span class="an-test-repo">${esc(step.test.repo)}</span>
+      </td>
+      <td class="an-col-num">+${num(step.new_runs)}</td>
+      <td class="an-col-rate">${meter(step.coverage, "cover")}</td>
+    </tr>`;
+}
+
+async function loadClusters() {
+  loading("an-clusters");
+
+  const controls = document.getElementById("analytics-cluster-controls");
+  const data = await getJSON("/analytics/clusters", query({
+    threshold: controls.elements.threshold.value,
+    run_key: controls.elements.run_key.value,
+    include_errors: controls.elements.include_errors.checked ? "true" : "",
+  }));
+
+  if (data.failing_runs === 0) {
+    document.getElementById("an-clusters").innerHTML =
+      `<p class="empty-state">Nothing failed in this window — no clusters to find.</p>`;
+    return;
+  }
+
+  // The headline is a sentence, not a chart: "how few tests still catch the
+  // failures" is one number and it deserves to be read directly.
+  // The headline number is "how few tests would do", so lead with the smallest
+  // set that still catches the overwhelming majority rather than the full cover.
+  const enough = data.minimal_set.findIndex(s => s.coverage >= 0.9);
+  const leadCount = enough >= 0 ? enough + 1 : data.minimal_set.length;
+  const leadCoverage = enough >= 0 ? data.minimal_set[enough].coverage : 1;
+  const headline =
+    `of ${num(data.tests)} failing tests cover ${pct(leadCoverage, 0)} of ${num(data.failing_runs)} failing runs`;
+
+  const clusters = data.clusters.length
+    ? data.clusters.map(clusterCard).join("")
+    : `<p class="empty-state">No test failed together with another often enough to cluster at this threshold.</p>`;
+
+  document.getElementById("an-clusters").innerHTML = `
+    <div class="an-hero">
+      <div class="an-hero-value">${leadCount}</div>
+      <div class="an-hero-label">${esc(headline)}</div>
+      <div class="an-hero-span">grouped by ${esc(data.run_key)}${data.include_errors ? ", errors included" : ""}</div>
+    </div>
+
+    <h5 class="an-section-title">Minimal covering set</h5>
+    <p class="an-note">
+      Greedy selection, most-covering first. Each entry catches failing runs no
+      entry above it caught. This is a good set, not a provably smallest one.
+    </p>
+    <table class="an-table">
+      <thead>
+        <tr>
+          <th class="an-col-num">#</th>
+          <th class="an-col-test">Test</th>
+          <th class="an-col-num">New runs</th>
+          <th class="an-col-rate">Coverage</th>
+        </tr>
+      </thead>
+      <tbody>${data.minimal_set.map(coverRowHTML).join("")}</tbody>
+    </table>
+
+    <h5 class="an-section-title">Co-failure clusters</h5>
+    <p class="an-note">
+      Tests whose failures overlap by at least the similarity threshold. Members
+      of a cluster tend to fail for the same underlying reason.
+    </p>
+    ${clusters}`;
+}
+
+// --- View switching ---
+
+function setView(next) {
+  view = next;
+  document.querySelectorAll("#an-views button").forEach(b => {
+    const active = b.dataset.view === view;
+    b.classList.toggle("active", active);
+    b.setAttribute("aria-selected", String(active));
+  });
+  document.querySelectorAll(".an-view").forEach(section => {
+    section.hidden = section.dataset.view !== view;
+  });
+  refresh();
+}
+
+async function refresh() {
+  clearError();
+  try {
+    if (view === "overview") await loadOverview();
+    else if (view === "tests") await loadTests();
+    else await loadClusters();
+  } catch (err) {
+    showError(err.message);
+    document.getElementById(
+      view === "overview" ? "an-overview" : view === "tests" ? "an-tests-body-wrap" : "an-clusters",
+    ).innerHTML = "";
+  }
+}
+
+// Called by the tab handler in app.js. The first activation loads; later ones
+// leave whatever the user was looking at alone.
+export function showAnalytics() {
+  if (loaded) return;
+  loaded = true;
+  setView(view);
+}
+
+// --- Wiring ---
+
+document.getElementById("analytics-filter")?.addEventListener("submit", e => {
+  e.preventDefault();
+  offset = 0;
+  refresh();
+});
+
+document.getElementById("an-clear")?.addEventListener("click", () => {
+  document.getElementById("analytics-filter").reset();
+  offset = 0;
+  refresh();
+});
+
+document.getElementById("an-views")?.addEventListener("click", e => {
+  const btn = e.target.closest("button[data-view]");
+  if (btn) setView(btn.dataset.view);
+});
+
+document.getElementById("an-presets")?.addEventListener("click", e => {
+  const btn = e.target.closest("button[data-preset]");
+  if (!btn) return;
+  const preset = PRESETS[btn.dataset.preset];
+  sortKey = preset.sort;
+  sortDesc = preset.desc;
+  offset = 0;
+  document.querySelectorAll("#an-presets button").forEach(b => {
+    b.classList.toggle("active", b === btn);
+  });
+  refresh();
+});
+
+document.getElementById("an-prev")?.addEventListener("click", () => {
+  offset = Math.max(0, offset - PAGE_SIZE);
+  refresh();
+});
+
+document.getElementById("an-next")?.addEventListener("click", () => {
+  if (offset + PAGE_SIZE < total) {
+    offset += PAGE_SIZE;
+    refresh();
+  }
+});
+
+document.getElementById("analytics-cluster-controls")?.addEventListener("change", () => {
+  if (view === "clusters") refresh();
+});

--- a/web/static/analytics.js
+++ b/web/static/analytics.js
@@ -11,7 +11,23 @@
 
 import { API_BASE, apiFetch, esc, formatTime } from "./common.js";
 
-const FILTER_FIELDS = ["repo", "branch", "finished_after", "finished_before"];
+// `ref` is one box matching a branch, a tag or a commit. Someone pasting what
+// they are looking at should not have to classify it first; the server does the
+// OR, so no guessing happens here.
+const FILTER_FIELDS = ["repo", "ref", "finished_after", "finished_before"];
+
+// Relative ranges are resolved at query time rather than written into the date
+// inputs, so "last 3 hours" still means the last three hours an hour later.
+const RANGES = {
+  "3h": 3 * 3600e3,
+  "12h": 12 * 3600e3,
+  "24h": 24 * 3600e3,
+  "7d": 7 * 86400e3,
+  "30d": 30 * 86400e3,
+  "90d": 90 * 86400e3,
+};
+
+const DEFAULT_RANGE = "3h";
 
 // Ranked answers to the questions the analytics page exists to ask. Each is
 // just a sort key — the table is one view, not four.
@@ -32,7 +48,9 @@ const LABEL_TEXT = {
 
 const PAGE_SIZE = 50;
 
-let loaded = false;
+// Analytics queries scan far more evidence than a search does, so the page waits
+// to be asked. Nothing is fetched until Apply is pressed.
+let applied = false;
 let view = "overview";
 let sortKey = "fail_rate";
 let sortDesc = true;
@@ -49,14 +67,33 @@ function num(n) {
   return n.toLocaleString("en-US");
 }
 
+function selectedRange() {
+  return document.getElementById("an-range")?.value || DEFAULT_RANGE;
+}
+
 function readFilters() {
   const form = document.getElementById("analytics-filter");
+  const range = selectedRange();
   const filters = {};
+
   for (const field of FILTER_FIELDS) {
+    // The custom date boxes only speak when the range is set to custom.
+    if ((field === "finished_after" || field === "finished_before") && range !== "custom") continue;
     const value = form.elements[field]?.value.trim();
     if (value) filters[field] = value;
   }
+
+  if (RANGES[range]) {
+    filters.finished_after = new Date(Date.now() - RANGES[range]).toISOString();
+  }
   return filters;
+}
+
+// The custom date inputs are only meaningful for a custom range, so they are
+// only on screen for one.
+function syncRangeInputs() {
+  const custom = selectedRange() === "custom";
+  document.querySelectorAll(".an-custom-range").forEach(el => { el.hidden = !custom; });
 }
 
 function query(extra = {}) {
@@ -89,6 +126,24 @@ function clearError() {
 function loading(containerId, message = "Loading...") {
   document.getElementById(containerId).innerHTML =
     `<p class="empty-state">${esc(message)}</p>`;
+}
+
+function containerFor(v) {
+  if (v === "overview") return "an-overview";
+  if (v === "tests") return "an-tests-body-wrap";
+  return "an-clusters";
+}
+
+function showPrompt() {
+  document.getElementById(containerFor(view)).innerHTML = `
+    <p class="empty-state">
+      Choose a time range and press <strong>Apply</strong>.
+    </p>`;
+  if (view === "tests") {
+    document.getElementById("an-tests-range").textContent = "";
+    document.getElementById("an-prev").disabled = true;
+    document.getElementById("an-next").disabled = true;
+  }
 }
 
 // --- Marks ---
@@ -415,36 +470,45 @@ function setView(next) {
 
 async function refresh() {
   clearError();
+  if (!applied) {
+    showPrompt();
+    return;
+  }
   try {
     if (view === "overview") await loadOverview();
     else if (view === "tests") await loadTests();
     else await loadClusters();
   } catch (err) {
     showError(err.message);
-    document.getElementById(
-      view === "overview" ? "an-overview" : view === "tests" ? "an-tests-body-wrap" : "an-clusters",
-    ).innerHTML = "";
+    document.getElementById(containerFor(view)).innerHTML = "";
   }
 }
 
-// Called by the tab handler in app.js. The first activation loads; later ones
-// leave whatever the user was looking at alone.
+// Called by the tab handler in app.js. Opening the tab shows the controls and
+// waits; it does not run a query of its own accord.
 export function showAnalytics() {
-  if (loaded) return;
-  loaded = true;
-  setView(view);
+  syncRangeInputs();
+  if (!applied) showPrompt();
 }
 
 // --- Wiring ---
 
 document.getElementById("analytics-filter")?.addEventListener("submit", e => {
   e.preventDefault();
+  applied = true;
   offset = 0;
   refresh();
 });
 
+document.getElementById("an-range")?.addEventListener("change", syncRangeInputs);
+
 document.getElementById("an-clear")?.addEventListener("click", () => {
-  document.getElementById("analytics-filter").reset();
+  const form = document.getElementById("analytics-filter");
+  form.reset();
+  syncRangeInputs();
+  // Clearing puts the page back to its opening state rather than running the
+  // default query, so it stays consistent with never having pressed Apply.
+  applied = false;
   offset = 0;
   refresh();
 });

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,4 +1,15 @@
-const API_BASE = "/api/v1";
+import {
+  API_BASE,
+  apiFetch,
+  esc,
+  formatTime,
+  getStoredAPIKey,
+  promptForAPIKey,
+  resultBadge,
+  setStoredAPIKey,
+  updateAuthUI,
+} from "./common.js";
+import { showAnalytics } from "./analytics.js";
 
 // Fields shown in the collapsed bar; everything else lives behind "More filters".
 const BAR_TEXT_FIELDS = ["repo", "rcs_ref"];
@@ -192,53 +203,6 @@ function refreshAdvancedToggle() {
   btn.textContent = n > 0 ? `More filters (${n})` : "More filters";
 }
 
-// --- Auth ---
-
-const API_KEY_STORAGE = "evidence_api_key";
-
-function getStoredAPIKey() {
-  return localStorage.getItem(API_KEY_STORAGE) || "";
-}
-
-function setStoredAPIKey(key) {
-  if (key) {
-    localStorage.setItem(API_KEY_STORAGE, key);
-  } else {
-    localStorage.removeItem(API_KEY_STORAGE);
-  }
-  updateAuthUI();
-}
-
-function updateAuthUI() {
-  const btn = document.getElementById("auth-logout");
-  if (btn) btn.hidden = !getStoredAPIKey();
-}
-
-function promptForAPIKey(msg) {
-  const key = prompt(msg || "Enter your API key:");
-  if (key !== null) {
-    setStoredAPIKey(key.trim());
-  }
-  return getStoredAPIKey();
-}
-
-// Wrapper around fetch that attaches Authorization header and handles 401.
-async function apiFetch(url, options = {}) {
-  const key = getStoredAPIKey();
-  if (key) {
-    options.headers = { ...options.headers, Authorization: `Bearer ${key}` };
-  }
-  const resp = await fetch(url, options);
-  if (resp.status === 401) {
-    const newKey = promptForAPIKey("Authentication required. Enter your API key:");
-    if (newKey) {
-      options.headers = { ...options.headers, Authorization: `Bearer ${newKey}` };
-      return fetch(url, options);
-    }
-  }
-  return resp;
-}
-
 // --- API ---
 
 // fetchWindow retrieves the current window of records.
@@ -346,20 +310,9 @@ function startHealthPolling() {
 
 // --- Rendering ---
 
-function resultBadge(result) {
-  const cls = result ? result.toLowerCase() : "unknown";
-  return `<span class="badge badge-${cls}">${result || "?"}</span>`;
-}
-
 function renderTags(metadata) {
   if (!metadata || !metadata.tags || metadata.tags.length === 0) return "";
   return metadata.tags.map(t => `<span class="badge badge-tag">${esc(t)}</span>`).join(" ");
-}
-
-function formatTime(iso) {
-  const d = new Date(iso);
-  const pad = n => String(n).padStart(2, "0");
-  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
 }
 
 // Parse a user-entered datetime string. Zoneless values are treated as UTC.
@@ -483,12 +436,6 @@ function renderDetail(record) {
 
   el.innerHTML = html;
   document.getElementById("detail-dialog").showModal();
-}
-
-function esc(str) {
-  const d = document.createElement("div");
-  d.textContent = str;
-  return d.innerHTML;
 }
 
 // --- Search ---
@@ -675,6 +622,7 @@ document.querySelectorAll(".nav-tab").forEach(tab => {
     tab.classList.add("active");
     document.querySelectorAll(".tab-content").forEach(s => s.hidden = true);
     document.getElementById(`tab-${target}`).hidden = false;
+    if (target === "analytics") showAnalytics();
   });
 });
 

--- a/web/static/common.js
+++ b/web/static/common.js
@@ -1,0 +1,71 @@
+// Shared between the search/add view (app.js) and the analytics view
+// (analytics.js). Extracted so the two can use the same API client and escaping
+// without importing each other, which would make the module graph cyclic.
+
+export const API_BASE = "/api/v1";
+
+// --- Auth ---
+
+const API_KEY_STORAGE = "evidence_api_key";
+
+export function getStoredAPIKey() {
+  return localStorage.getItem(API_KEY_STORAGE) || "";
+}
+
+export function setStoredAPIKey(key) {
+  if (key) {
+    localStorage.setItem(API_KEY_STORAGE, key);
+  } else {
+    localStorage.removeItem(API_KEY_STORAGE);
+  }
+  updateAuthUI();
+}
+
+export function updateAuthUI() {
+  const btn = document.getElementById("auth-logout");
+  if (btn) btn.hidden = !getStoredAPIKey();
+}
+
+export function promptForAPIKey(msg) {
+  const key = prompt(msg || "Enter your API key:");
+  if (key !== null) {
+    setStoredAPIKey(key.trim());
+  }
+  return getStoredAPIKey();
+}
+
+// Wrapper around fetch that attaches Authorization header and handles 401.
+export async function apiFetch(url, options = {}) {
+  const key = getStoredAPIKey();
+  if (key) {
+    options.headers = { ...options.headers, Authorization: `Bearer ${key}` };
+  }
+  const resp = await fetch(url, options);
+  if (resp.status === 401) {
+    const newKey = promptForAPIKey("Authentication required. Enter your API key:");
+    if (newKey) {
+      options.headers = { ...options.headers, Authorization: `Bearer ${newKey}` };
+      return fetch(url, options);
+    }
+  }
+  return resp;
+}
+
+// --- Formatting ---
+
+export function esc(str) {
+  const d = document.createElement("div");
+  d.textContent = str;
+  return d.innerHTML;
+}
+
+export function formatTime(iso) {
+  const d = new Date(iso);
+  const pad = n => String(n).padStart(2, "0");
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
+}
+
+export function resultBadge(result) {
+  const cls = result ? result.toLowerCase() : "unknown";
+  return `<span class="badge badge-${cls}">${result || "?"}</span>`;
+}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -211,6 +211,16 @@
                     <label class="an-field">Branch, tag or commit
                         <input type="text" name="ref" placeholder="main, v2.0.0 or abc123">
                     </label>
+                    <label class="an-field">Show
+                        <select name="label" id="an-label">
+                            <option value="">All tests</option>
+                            <option value="always_failing">Always failing</option>
+                            <option value="stable">Never fails</option>
+                            <option value="flaky">Flaky</option>
+                            <option value="infra_heavy">Infra-heavy</option>
+                            <option value="sparse">Too few runs to judge</option>
+                        </select>
+                    </label>
                     <label class="an-field">Time range
                         <select name="range" id="an-range">
                             <option value="3h" selected>Last 3 hours</option>
@@ -247,13 +257,6 @@
             <div id="an-overview" class="an-view" data-view="overview"></div>
 
             <div id="an-tests" class="an-view" data-view="tests" hidden>
-                <div id="an-presets" class="an-presets">
-                    <span class="an-presets-label">Show</span>
-                    <button type="button" data-preset="always_fails" class="active">Always fails</button>
-                    <button type="button" data-preset="never_fails">Never fails</button>
-                    <button type="button" data-preset="infra">Most infra errors</button>
-                    <button type="button" data-preset="flakiest">Flakiest</button>
-                </div>
                 <div class="an-table-bar">
                     <span id="an-tests-range"></span>
                     <div class="an-page-nav">

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -13,6 +13,7 @@
             <ul><li><strong>Evidence Store</strong></li></ul>
             <ul>
                 <li><a href="#" class="nav-tab active" data-tab="search">Search</a></li>
+                <li><a href="#" class="nav-tab" data-tab="analytics">Analytics</a></li>
                 <li><a href="#" class="nav-tab" data-tab="add">Add Result</a></li>
                 <li id="health-status"></li>
                 <li><a href="#" id="auth-login" class="secondary" style="font-size:0.8em">Set API Key</a></li>
@@ -199,6 +200,78 @@
                     <tbody id="inherited-body"></tbody>
                 </table>
             </details>
+        </section>
+
+        <section id="tab-analytics" class="tab-content" hidden>
+            <form id="analytics-filter">
+                <div id="an-bar">
+                    <label class="an-field">Repo
+                        <input type="text" name="repo" placeholder="org/repo or ~^org/.*" list="repos-list">
+                    </label>
+                    <label class="an-field">Branch
+                        <input type="text" name="branch" placeholder="main or ~^release/.*">
+                    </label>
+                    <label class="an-field">After <small>(UTC)</small>
+                        <input type="text" name="finished_after" placeholder="2026-01-01">
+                    </label>
+                    <label class="an-field">Before <small>(UTC)</small>
+                        <input type="text" name="finished_before" placeholder="2026-12-31">
+                    </label>
+                    <div class="an-actions">
+                        <button type="submit">Apply</button>
+                        <button type="button" class="secondary" id="an-clear">Clear</button>
+                    </div>
+                </div>
+            </form>
+
+            <div id="an-views" role="tablist" aria-label="Analytics view">
+                <button type="button" role="tab" data-view="overview" class="active" aria-selected="true">Overview</button>
+                <button type="button" role="tab" data-view="tests" aria-selected="false">Tests</button>
+                <button type="button" role="tab" data-view="clusters" aria-selected="false">Clusters</button>
+            </div>
+
+            <div id="an-error" class="an-error" hidden></div>
+
+            <div id="an-overview" class="an-view" data-view="overview"></div>
+
+            <div id="an-tests" class="an-view" data-view="tests" hidden>
+                <div id="an-presets" class="an-presets">
+                    <span class="an-presets-label">Show</span>
+                    <button type="button" data-preset="always_fails" class="active">Always fails</button>
+                    <button type="button" data-preset="never_fails">Never fails</button>
+                    <button type="button" data-preset="infra">Most infra errors</button>
+                    <button type="button" data-preset="flakiest">Flakiest</button>
+                </div>
+                <div class="an-table-bar">
+                    <span id="an-tests-range"></span>
+                    <div class="an-page-nav">
+                        <button type="button" class="secondary outline" id="an-prev" disabled>&lsaquo; Prev</button>
+                        <button type="button" class="secondary outline" id="an-next" disabled>Next &rsaquo;</button>
+                    </div>
+                </div>
+                <div id="an-tests-body-wrap"></div>
+                <p class="an-note">Select a row to open the matching records in Search.</p>
+            </div>
+
+            <div id="an-clusters-view" class="an-view" data-view="clusters" hidden>
+                <form id="analytics-cluster-controls" class="an-cluster-controls">
+                    <label class="an-field">Similarity
+                        <input type="number" name="threshold" value="0.6" min="0" max="1" step="0.05">
+                    </label>
+                    <label class="an-field">Group runs by
+                        <select name="run_key">
+                            <option value="auto">Invocation, else commit</option>
+                            <option value="invocation">Invocation id</option>
+                            <option value="commit">Commit</option>
+                        </select>
+                    </label>
+                    <label class="an-checkbox">
+                        <input type="checkbox" name="include_errors">
+                        Count infra errors as failures
+                    </label>
+                </form>
+                <div id="an-clusters"></div>
+            </div>
         </section>
 
         <dialog id="template-dialog">

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -208,13 +208,25 @@
                     <label class="an-field">Repo
                         <input type="text" name="repo" placeholder="org/repo or ~^org/.*" list="repos-list">
                     </label>
-                    <label class="an-field">Branch
-                        <input type="text" name="branch" placeholder="main or ~^release/.*">
+                    <label class="an-field">Branch, tag or commit
+                        <input type="text" name="ref" placeholder="main, v2.0.0 or abc123">
                     </label>
-                    <label class="an-field">After <small>(UTC)</small>
+                    <label class="an-field">Time range
+                        <select name="range" id="an-range">
+                            <option value="3h" selected>Last 3 hours</option>
+                            <option value="12h">Last 12 hours</option>
+                            <option value="24h">Last 24 hours</option>
+                            <option value="7d">Last 7 days</option>
+                            <option value="30d">Last 30 days</option>
+                            <option value="90d">Last 90 days</option>
+                            <option value="all">All time</option>
+                            <option value="custom">Custom range</option>
+                        </select>
+                    </label>
+                    <label class="an-field an-custom-range" hidden>After <small>(UTC)</small>
                         <input type="text" name="finished_after" placeholder="2026-01-01">
                     </label>
-                    <label class="an-field">Before <small>(UTC)</small>
+                    <label class="an-field an-custom-range" hidden>Before <small>(UTC)</small>
                         <input type="text" name="finished_before" placeholder="2026-12-31">
                     </label>
                     <div class="an-actions">

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -804,10 +804,16 @@ body > main {
     color: var(--an-muted);
 }
 
+/* Pico gives form controls 15px of padding top and bottom. Combined with a
+   fixed 40px border-box height that leaves a 10px content box for a 27px line,
+   and `overflow: clip` then hides the text entirely — the control looks empty.
+   Zeroing the block padding is what makes the fixed height safe. */
 #tab-analytics .an-field input,
 #tab-analytics .an-field select {
     margin: 0;
     height: 40px;
+    padding-block: 0;
+    line-height: 1.2;
     font-size: 0.9rem;
     --pico-font-size: 0.9rem;
 }
@@ -1134,8 +1140,8 @@ body > main {
     margin-bottom: 1.2rem;
 }
 
-.an-cluster-controls .an-field input,
-.an-cluster-controls .an-field select { width: 12rem; }
+.an-cluster-controls .an-field input { width: 8rem; }
+.an-cluster-controls .an-field select { width: 15rem; }
 
 .an-checkbox {
     display: flex;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -761,3 +761,434 @@ body > main {
         max-height: calc(100vh - 14em);
     }
 }
+
+/* ---------------------------------------------------------------------------
+   Analytics
+
+   Marks are HTML/CSS: a flex row for the part-to-whole bar, a width for each
+   meter. Result colours reuse the badge palette so one page never shows two
+   greens, and they are always accompanied by a written value — status hues are
+   red/green by nature and cannot carry meaning unaided.
+   --------------------------------------------------------------------------- */
+
+#tab-analytics {
+    --an-pass: #2d9e2d;
+    --an-fail: #d32f2f;
+    --an-error: #e67e22;
+    --an-skipped: #888;
+    --an-flip: #6a5acd;
+    --an-cover: #2a78d6;
+    --an-track: #e9e9e6;
+    --an-hairline: #e1e0d9;
+    --an-muted: #6b6a66;
+}
+
+#tab-analytics [hidden] { display: none; }
+
+/* Filter bar */
+
+#an-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 0.6rem;
+    margin-bottom: 0.9rem;
+}
+
+.an-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--an-muted);
+}
+
+#tab-analytics .an-field input,
+#tab-analytics .an-field select {
+    margin: 0;
+    height: 40px;
+    font-size: 0.9rem;
+    --pico-font-size: 0.9rem;
+}
+
+#an-bar .an-field input { width: 15rem; }
+#an-bar .an-field:nth-child(n+3) input { width: 10rem; }
+
+.an-actions {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.an-actions button {
+    height: 40px;
+    margin: 0;
+    padding: 0 1rem;
+    font-size: 0.9rem;
+}
+
+/* Sub-view switcher */
+
+#an-views {
+    display: flex;
+    gap: 0.25rem;
+    border-bottom: 1px solid var(--an-hairline);
+    margin-bottom: 1.1rem;
+}
+
+#an-views button {
+    margin: 0;
+    padding: 0.5rem 1rem;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    color: var(--an-muted);
+    font-size: 0.9rem;
+    font-weight: 500;
+    width: auto;
+}
+
+#an-views button.active {
+    color: var(--pico-primary, #1095c1);
+    border-bottom-color: var(--pico-primary, #1095c1);
+}
+
+.an-error {
+    padding: 0.7rem 0.9rem;
+    margin-bottom: 1rem;
+    border-left: 3px solid var(--an-fail);
+    background: #fdf0f0;
+    font-size: 0.9rem;
+}
+
+/* Hero figure and stat tiles */
+
+.an-hero {
+    margin-bottom: 1.4rem;
+}
+
+.an-hero-value {
+    font-size: 3rem;
+    line-height: 1.05;
+    font-weight: 600;
+}
+
+.an-hero-label {
+    font-size: 1rem;
+    color: var(--an-muted);
+}
+
+.an-hero-span {
+    margin-top: 0.2rem;
+    font-size: 0.8rem;
+    color: var(--an-muted);
+}
+
+.an-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+    gap: 0.6rem;
+    margin-bottom: 1.6rem;
+}
+
+.an-tile {
+    padding: 0.7rem 0.85rem;
+    border: 1px solid var(--an-hairline);
+    border-radius: 6px;
+}
+
+.an-tile-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.an-tile-label {
+    font-size: 0.8rem;
+    color: var(--an-muted);
+}
+
+.an-tile-hint {
+    font-size: 0.7rem;
+    color: var(--an-muted);
+    opacity: 0.8;
+}
+
+.an-section-title {
+    margin: 1.6rem 0 0.5rem;
+    font-size: 0.95rem;
+}
+
+.an-note {
+    margin: 0 0 0.8rem;
+    font-size: 0.8rem;
+    color: var(--an-muted);
+}
+
+/* Stacked part-to-whole bar. 2px surface gaps between segments, rounded outer
+   ends only — the interior joins stay square so the bar reads as one length. */
+
+.an-stack {
+    display: flex;
+    gap: 2px;
+    height: 22px;
+    margin-bottom: 0.6rem;
+}
+
+.an-seg {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2px;
+    overflow: hidden;
+}
+
+.an-seg:first-child { border-radius: 4px 0 0 4px; }
+.an-seg:last-child  { border-radius: 0 4px 4px 0; }
+.an-seg:only-child  { border-radius: 4px; }
+
+.an-seg-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+    padding: 0 0.3rem;
+}
+
+.an-seg-pass,    .an-swatch.an-seg-pass    { background: var(--an-pass); }
+.an-seg-fail,    .an-swatch.an-seg-fail    { background: var(--an-fail); }
+.an-seg-error,   .an-swatch.an-seg-error   { background: var(--an-error); }
+.an-seg-skipped, .an-swatch.an-seg-skipped { background: var(--an-skipped); }
+
+.an-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 1.2rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.an-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+}
+
+.an-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex: none;
+}
+
+.an-legend-name { color: var(--an-muted); }
+.an-legend-value { font-variant-numeric: tabular-nums; font-weight: 600; }
+.an-legend-share { color: var(--an-muted); font-variant-numeric: tabular-nums; }
+
+/* Meters */
+
+.an-meter-cell {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.an-meter {
+    flex: 1;
+    min-width: 2.5rem;
+    height: 6px;
+    background: var(--an-track);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.an-meter-fill {
+    height: 100%;
+    border-radius: 0 3px 3px 0;
+}
+
+.an-meter-fail  { background: var(--an-fail); }
+.an-meter-error { background: var(--an-error); }
+.an-meter-flip  { background: var(--an-flip); }
+.an-meter-cover { background: var(--an-cover); }
+
+.an-num {
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+    min-width: 3.2rem;
+    text-align: right;
+}
+
+.an-num-plain { color: var(--an-muted); display: inline-block; }
+
+.an-rate {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 3px;
+}
+
+.an-rate .an-num { min-width: 0; }
+
+.an-rate .an-meter {
+    flex: none;
+    width: 100%;
+    height: 6px;
+}
+
+/* Tables */
+
+.an-table-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin: 0.8rem 0 0.4rem;
+    font-size: 0.85rem;
+    color: var(--an-muted);
+}
+
+.an-page-nav { display: flex; gap: 0.3rem; }
+
+.an-page-nav button {
+    margin: 0;
+    padding: 0.25rem 0.7rem;
+    font-size: 0.8rem;
+    width: auto;
+}
+
+.an-table {
+    width: 100%;
+    table-layout: fixed;
+    font-size: 0.85rem;
+    margin: 0;
+}
+
+.an-table th {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--an-muted);
+    white-space: nowrap;
+}
+
+.an-sortable { cursor: pointer; user-select: none; }
+.an-sortable:hover { color: var(--pico-primary, #1095c1); }
+.an-sorted { color: var(--pico-primary, #1095c1); }
+
+.an-table tbody tr[data-procedure] { cursor: pointer; }
+.an-table tbody tr[data-procedure]:hover { background: rgba(0, 0, 0, 0.03); }
+
+/* The test name takes whatever the fixed columns leave. Rate columns keep one
+   width whether or not they currently hold a meter, so sorting never reflows
+   the table. */
+.an-col-num  { text-align: right; font-variant-numeric: tabular-nums; width: 4.5rem; }
+.an-col-rate { width: 8rem; text-align: right; }
+.an-col-time { width: 8.5rem; white-space: nowrap; font-variant-numeric: tabular-nums; }
+.an-col-labels { width: 8.5rem; }
+.an-col-test { width: auto; }
+
+.an-test-name {
+    display: block;
+    font-family: var(--pico-font-family-monospace, monospace);
+    font-size: 0.82rem;
+    overflow-wrap: anywhere;
+}
+
+.an-test-repo {
+    display: block;
+    font-size: 0.72rem;
+    color: var(--an-muted);
+}
+
+.an-muted { color: var(--an-muted); }
+
+/* Label chips */
+
+.an-chip {
+    display: inline-block;
+    padding: 0.1rem 0.45rem;
+    border-radius: 10px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.an-chip-stable         { background: #e3f3e3; color: #1d661d; }
+.an-chip-always_failing { background: #fbe3e3; color: #9c2020; }
+.an-chip-flaky          { background: #ede9fb; color: #4a3aa7; }
+.an-chip-infra_heavy    { background: #fdeede; color: #9a5410; }
+.an-chip-sparse         { background: #ececea; color: #56554f; }
+
+/* Clusters */
+
+.an-cluster-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 1rem;
+    margin-bottom: 1.2rem;
+}
+
+.an-cluster-controls .an-field input,
+.an-cluster-controls .an-field select { width: 12rem; }
+
+.an-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0 0 0.5rem;
+    font-size: 0.85rem;
+}
+
+.an-checkbox input { margin: 0; }
+
+.an-cluster {
+    border: 1px solid var(--an-hairline);
+    border-radius: 6px;
+    padding: 0.7rem 0.9rem;
+    margin-bottom: 0.6rem;
+}
+
+.an-cluster-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.9rem;
+    margin-bottom: 0.4rem;
+}
+
+.an-cluster-title { font-weight: 600; }
+
+.an-cluster-stat {
+    font-size: 0.78rem;
+    color: var(--an-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.an-cluster-members {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.9rem;
+}
+
+.an-cluster-members li {
+    font-family: var(--pico-font-family-monospace, monospace);
+    font-size: 0.78rem;
+    list-style: none;
+}
+
+.an-cluster-members li::marker { content: ""; }
+
+@media (max-width: 900px) {
+    #an-bar .an-field input,
+    #an-bar .an-field:nth-child(n+3) input { width: 100%; }
+    .an-field { flex: 1 1 12rem; }
+    .an-col-labels, .an-col-time { display: none; }
+}

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -827,11 +827,52 @@ body > main {
     gap: 0.4rem;
 }
 
-.an-actions button {
+/* The filter-bar actions and the preset buttons are the same kind of control
+   and have to stay the same size, so they share one rule rather than two that
+   drift apart. */
+#tab-analytics .an-actions button,
+#tab-analytics .an-presets button {
     height: 40px;
+    width: auto;
     margin: 0;
     padding: 0 1rem;
     font-size: 0.9rem;
+    line-height: 1.2;
+}
+
+/* Presets */
+
+.an-presets {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 0.6rem;
+}
+
+.an-presets-label {
+    font-size: 0.8rem;
+    color: var(--an-muted);
+    margin-right: 0.2rem;
+}
+
+/* Only the applied preset is filled in; the rest read as the alternatives they
+   are, so the current ranking is visible at a glance. */
+#tab-analytics .an-presets button {
+    background: transparent;
+    border: 1px solid var(--an-hairline);
+    color: var(--an-muted);
+}
+
+#tab-analytics .an-presets button:hover {
+    border-color: var(--pico-primary, #1095c1);
+    color: var(--pico-primary, #1095c1);
+}
+
+#tab-analytics .an-presets button.active {
+    background: var(--pico-primary, #1095c1);
+    border-color: var(--pico-primary, #1095c1);
+    color: #fff;
 }
 
 /* Sub-view switcher */

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -812,8 +812,9 @@ body > main {
     --pico-font-size: 0.9rem;
 }
 
-#an-bar .an-field input { width: 15rem; }
-#an-bar .an-field:nth-child(n+3) input { width: 10rem; }
+#an-bar .an-field input { width: 13rem; }
+#an-bar .an-field select { width: 11.5rem; }
+#an-bar .an-custom-range input { width: 9rem; }
 
 .an-actions {
     display: flex;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -827,52 +827,13 @@ body > main {
     gap: 0.4rem;
 }
 
-/* The filter-bar actions and the preset buttons are the same kind of control
-   and have to stay the same size, so they share one rule rather than two that
-   drift apart. */
-#tab-analytics .an-actions button,
-#tab-analytics .an-presets button {
+#tab-analytics .an-actions button {
     height: 40px;
     width: auto;
     margin: 0;
     padding: 0 1rem;
     font-size: 0.9rem;
     line-height: 1.2;
-}
-
-/* Presets */
-
-.an-presets {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.4rem;
-    margin-bottom: 0.6rem;
-}
-
-.an-presets-label {
-    font-size: 0.8rem;
-    color: var(--an-muted);
-    margin-right: 0.2rem;
-}
-
-/* Only the applied preset is filled in; the rest read as the alternatives they
-   are, so the current ranking is visible at a glance. */
-#tab-analytics .an-presets button {
-    background: transparent;
-    border: 1px solid var(--an-hairline);
-    color: var(--an-muted);
-}
-
-#tab-analytics .an-presets button:hover {
-    border-color: var(--pico-primary, #1095c1);
-    color: var(--pico-primary, #1095c1);
-}
-
-#tab-analytics .an-presets button.active {
-    background: var(--pico-primary, #1095c1);
-    border-color: var(--pico-primary, #1095c1);
-    color: #fff;
 }
 
 /* Sub-view switcher */
@@ -1062,6 +1023,7 @@ body > main {
 .an-meter-error { background: var(--an-error); }
 .an-meter-flip  { background: var(--an-flip); }
 .an-meter-cover { background: var(--an-cover); }
+.an-meter-reliability { background: var(--an-pass); }
 
 .an-num {
     font-size: 0.8rem;
@@ -1127,16 +1089,26 @@ body > main {
 .an-sortable:hover { color: var(--pico-primary, #1095c1); }
 .an-sorted { color: var(--pico-primary, #1095c1); }
 
+/* A faint arrow on hover says the header is a control, without putting eight
+   arrows on screen at once. */
+#tab-analytics .an-sortable:not(.an-sorted)::after {
+    content: " \25BE";
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+}
+
+#tab-analytics .an-sortable:not(.an-sorted):hover::after { opacity: 0.55; }
+
 .an-table tbody tr[data-procedure] { cursor: pointer; }
 .an-table tbody tr[data-procedure]:hover { background: rgba(0, 0, 0, 0.03); }
 
 /* The test name takes whatever the fixed columns leave. Rate columns keep one
    width whether or not they currently hold a meter, so sorting never reflows
    the table. */
-.an-col-num  { text-align: right; font-variant-numeric: tabular-nums; width: 4.5rem; }
-.an-col-rate { width: 8rem; text-align: right; }
-.an-col-time { width: 8.5rem; white-space: nowrap; font-variant-numeric: tabular-nums; }
-.an-col-labels { width: 8.5rem; }
+.an-col-num  { text-align: right; font-variant-numeric: tabular-nums; width: 4rem; }
+.an-col-rate { width: 6.5rem; text-align: right; }
+.an-col-time { width: 8rem; white-space: nowrap; font-variant-numeric: tabular-nums; }
+.an-col-labels { width: 7.5rem; }
 .an-col-test { width: auto; }
 
 .an-test-name {


### PR DESCRIPTION
Phase 3 of `docs/analytics-plan.md`, for #58. The metrics and clusters from #63 and #64 were reachable only by `curl`; this is the page that reads them.

## What's there

Three sub-views over a shared filter bar:

- **Overview** — hero pass rate, stat tiles, and the result distribution as a part-to-whole bar.
- **Tests** — sortable table with presets for the four questions the feature exists to answer (*Always fails / Never fails / Most infra errors / Flakiest*). Selecting a row opens the matching records in Search.
- **Clusters** — the minimal covering set led by "N of M failing tests cover X% of the failing runs", plus the co-failure groups, with live controls for similarity, run key, and whether errors count.

Drill-down needed no plumbing on the Search side — that view already restores its filters from the URL, so it's a link. Verified end to end: click a row, land on Search with `repo` + `procedure_ref` applied and 50 matching records.

## The chart decision

You didn't call this either time I raised it, so I took the recommendation: **no library, and in the end no SVG either.** The two marks the page needs are a part-to-whole bar and a meter — a flex row and a width. That's less code than the SVG equivalent, keeps the page working with nothing to vendor, and sidesteps viewBox scaling. Easy to swap: it's one module.

## Colour, and a finding about the existing badges

Result colours reuse the app's existing badge palette so a single page never shows two different greens.

While checking them I ran the palette through a colour-blindness validator, and **the current badge colours fail**: PASS `#2d9e2d` vs FAIL `#d32f2f` measure ΔE 3.3 under deuteranopia — the classic red/green confusion. That's pre-existing, and it also affects the Search tab.

I did **not** change them, for two reasons: the badges always carry their text (`PASS`, `FAIL`), which is the accepted mitigation, and the validated reference palette fails the same check by 4.1 — status colours are red/green by nature. Switching hexes would have been churn with no measurable gain (white-text contrast differs by <0.2 across the two sets).

So the mitigation is applied consistently instead: **no mark carries meaning by colour alone.** Segments are labelled with their counts, the legend repeats every result with count and share, and every meter sits beside its number.

## One design call worth a look

**Only the column being sorted on draws a meter.** A bar in all three rate cells is three little charts per row competing for attention; a bar in the column the reader chose to rank by is the comparison they actually asked for. The other cells keep their numbers, so nothing is lost, and the columns hold one width either way so sorting never reflows the table.

## Refactor

`apiFetch` and the formatting helpers move to `common.js`, so the two views share them without importing each other — `app.js` importing `analytics.js` and vice versa would have made the module graph cyclic.

## Testing

Driven in a real browser (Playwright) against a 120k-record seeded database, and I looked at every view rather than assuming — which is how I caught four layout bugs that no unit test would have found:

- the test-name column collapsing to one character (`overflow-wrap: anywhere` drops min-content width; fixed by `table-layout: fixed`),
- the emphasised meter rendering at zero height (`flex: 1` inside a column flex container),
- Pico's `<article>` and `::marker` styles leaking into the cluster cards,
- an overflowing table header.

Also verified: no console errors on any view, Search/Add/detail-dialog still work after the `common.js` extraction, and the narrow-viewport layout. Full Go suite and `bazel build //...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)