### PR TITLE
Refuse analytics queries that cannot finish in budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This starts PostgreSQL 16 and the Evidence Store server on port 8000.
 | `EVIDENCE_MAX_PAGE_SIZE` | `1000` | Max page size |
 | `EVIDENCE_MAX_BATCH_SIZE` | `1000` | Max records per batch |
 | `EVIDENCE_ANALYTICS_CACHE_TTL_SECONDS` | `30` | How long an analytics aggregation is reused for an identical filter (`0` disables) |
+| `EVIDENCE_ANALYTICS_QUERY_TIMEOUT_SECONDS` | `15` | Budget for one analytics aggregation before it is refused (`0` disables) |
 | `EVIDENCE_API_KEYS` | *(empty — auth disabled)* | Comma-separated API keys (see [Authentication](#authentication)) |
 | `EVIDENCE_RATE_LIMIT_READ_RPS` | `0` (disabled) | Sustained reads per second per caller (see [Rate limiting](#rate-limiting)) |
 | `EVIDENCE_RATE_LIMIT_WRITE_RPS` | `0` (disabled) | Sustained writes per second per caller |
@@ -470,6 +471,7 @@ curl -o tests.csv "http://localhost:8000/api/v1/analytics/tests?repo=org/repo&so
 The export covers the whole filtered set rather than the requested page — filters and sorting apply, `limit` and `offset` do not. Rates are written as plain decimals (`0.106`) rather than percentages so a spreadsheet reads them as numbers, and labels come through space-separated in one column. The **Export CSV** button on the Analytics tab downloads exactly what the table is currently showing.
 
 Column order is a contract: new columns are appended, existing ones are not reordered or renamed.
+A query that cannot finish within `EVIDENCE_ANALYTICS_QUERY_TIMEOUT_SECONDS` is refused the same way. Analytics scales with the rows scanned, so an unfiltered query over a long window on a large corpus can take tens of seconds; without a budget it runs until the server's request timeout and the caller gets a dropped connection rather than an answer. Scoping to a repo is what keeps these queries fast — a full year of one repo's history aggregates in about two seconds at six million rows.
 
 ### Co-failure clusters and test selection
 

--- a/docs/analytics-plan.md
+++ b/docs/analytics-plan.md
@@ -216,9 +216,46 @@ Tests first at each step, per the project's practice — the metric math lands a
 - `web/static/analytics.js`, the nav tab, the three sub-views, deep-linking into Search.
 
 **Phase 4 — follow-ons, only if measurement demands**
-- Short-TTL in-memory response cache keyed by filter hash (dashboards re-request identical windows).
-- Nightly rollup table if the live aggregation is too slow.
-- CSV export of the tests table.
+- ~~Short-TTL in-memory response cache~~ — done, though not for the reason predicted. See below.
+- ~~Nightly rollup table if the live aggregation is too slow~~ — **measured and declined.** See below.
+- ~~CSV export of the tests table~~ — done.
+
+### What the measurement said
+
+Measured against 6,050,000 rows (12 repos, 88 procedures, one year of history;
+1664 MB table, 3888 MB with indexes):
+
+| window | one repo (605k rows) | all 12 repos (6.05M rows) |
+|---|---|---|
+| 3 hours | 0.081 s | 0.230 s |
+| 24 hours | 0.187 s | 1.260 s |
+| 7 days | 0.313 s | 4.562 s |
+| 30 days | 0.609 s | 11.107 s |
+| 90 days | 1.136 s | 28.423 s |
+| 365 days | 1.963 s | **connection dropped at 30 s** |
+
+Two conclusions, neither of them the one the plan expected.
+
+**A rollup table is not warranted.** Analytics is scoped to a repo — that is how
+the UI drives it and how the plan designed it. The worst case there is a full
+year at 2 seconds, and with the aggregation cache a re-sort of that result is
+free. A nightly rollup would buy a second and a half on the rarest query in
+exchange for a background worker, a second schema, an invalidation story, and
+answers that are stale by up to a day. That is a bad trade, and it stays
+undone.
+
+**The real defect was the failure mode, not the speed.** An unfiltered year-long
+query did not return an error — it ran until the server's request timeout and
+dropped the connection, so the caller got no status, no body, and nothing to act
+on. That is now a query budget
+(`EVIDENCE_ANALYTICS_QUERY_TIMEOUT_SECONDS`, default 15): the same query comes
+back as a `422` naming the limit and advising the caller to narrow the filter or
+the window, consistent with the existing size caps.
+
+**The cache earns its place for a different reason than predicted.** The plan
+justified it with dashboards re-requesting identical windows. The actual win is
+that sorting and paging happen in Go after the query, so every click on a column
+header re-runs an aggregation whose inputs did not change.
 
 ## Testing
 

--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -19,6 +20,31 @@ import (
 type AnalyticsHandler struct {
 	evidence *store.EvidenceStore
 	cfg      *config.Config
+}
+
+// budget bounds one aggregation. Without it a wide enough query simply runs
+// until the server's request timeout drops the connection, and the caller gets
+// no response at all -- no status, no body, nothing to act on. Failing early
+// with the same advice the size caps give is strictly more useful.
+//
+// The returned check reports whether the budget is what expired, as opposed to
+// the caller having gone away, which is not an error worth reporting.
+func (h *AnalyticsHandler) budget(r *http.Request) (context.Context, context.CancelFunc, func(error) bool) {
+	if h.cfg.AnalyticsQueryTimeout <= 0 {
+		return r.Context(), func() {}, func(error) bool { return false }
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), h.cfg.AnalyticsQueryTimeout)
+	exceeded := func(err error) bool {
+		return errors.Is(err, context.DeadlineExceeded) && r.Context().Err() == nil
+	}
+	return ctx, cancel, exceeded
+}
+
+func (h *AnalyticsHandler) writeBudgetExceeded(w http.ResponseWriter) {
+	writeError(w, http.StatusUnprocessableEntity, fmt.Sprintf(
+		"query did not finish within %s; narrow the filter or the time window",
+		h.cfg.AnalyticsQueryTimeout))
 }
 
 func NewAnalyticsHandler(es *store.EvidenceStore, cfg *config.Config) *AnalyticsHandler {
@@ -91,11 +117,18 @@ func (h *AnalyticsHandler) Tests(w http.ResponseWriter, r *http.Request) {
 		offset = n
 	}
 
-	stats, err := h.evidence.TestStats(r.Context(), store.TestStatsParams{
+	ctx, cancel, budgetExceeded := h.budget(r)
+	defer cancel()
+
+	stats, err := h.evidence.TestStats(ctx, store.TestStatsParams{
 		Filter:              filter,
 		GroupByEvidenceType: q.Get("group_by") == "evidence_type",
 	})
 	if err != nil {
+		if budgetExceeded(err) {
+			h.writeBudgetExceeded(w)
+			return
+		}
 		var tooMany *store.ErrTooManyGroups
 		if errors.As(err, &tooMany) {
 			writeError(w, http.StatusUnprocessableEntity, tooMany.Error())
@@ -204,12 +237,19 @@ func (h *AnalyticsHandler) Clusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	occurrences, err := h.evidence.FailureOccurrences(r.Context(), store.FailureOccurrenceParams{
+	ctx, cancel, budgetExceeded := h.budget(r)
+	defer cancel()
+
+	occurrences, err := h.evidence.FailureOccurrences(ctx, store.FailureOccurrenceParams{
 		Filter:        filter,
 		RunKey:        runKey,
 		IncludeErrors: includeErrors,
 	})
 	if err != nil {
+		if budgetExceeded(err) {
+			h.writeBudgetExceeded(w)
+			return
+		}
 		var tooMany *store.ErrTooManyRows
 		if errors.As(err, &tooMany) {
 			writeError(w, http.StatusUnprocessableEntity, tooMany.Error())
@@ -261,8 +301,15 @@ func (h *AnalyticsHandler) Summary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sum, err := h.evidence.Summary(r.Context(), filter)
+	ctx, cancel, budgetExceeded := h.budget(r)
+	defer cancel()
+
+	sum, err := h.evidence.Summary(ctx, filter)
 	if err != nil {
+		if budgetExceeded(err) {
+			h.writeBudgetExceeded(w)
+			return
+		}
 		slog.Error("failed to summarize evidence", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,9 @@ type Config struct {
 	// query, so this mostly serves those without a round trip; the cost is that
 	// a window can lag new evidence by up to this long.
 	AnalyticsCacheTTL time.Duration
+	// AnalyticsQueryTimeout bounds how long a single analytics aggregation may
+	// run. Zero means no budget beyond the server's own request timeout.
+	AnalyticsQueryTimeout time.Duration
 }
 
 // RateLimit configures per-caller token-bucket limits. Zero RPS disables
@@ -54,10 +57,16 @@ func Load() (*Config, error) {
 		LogLevel:        envOrDefault("EVIDENCE_LOG_LEVEL", "INFO"),
 		AnalyticsCacheTTL: time.Duration(
 			envOrDefaultInt("EVIDENCE_ANALYTICS_CACHE_TTL_SECONDS", 30)) * time.Second,
+		AnalyticsQueryTimeout: time.Duration(
+			envOrDefaultInt("EVIDENCE_ANALYTICS_QUERY_TIMEOUT_SECONDS", 15)) * time.Second,
 	}
 
 	if cfg.AnalyticsCacheTTL < 0 {
 		return nil, fmt.Errorf("EVIDENCE_ANALYTICS_CACHE_TTL_SECONDS must not be negative")
+	}
+
+	if cfg.AnalyticsQueryTimeout < 0 {
+		return nil, fmt.Errorf("EVIDENCE_ANALYTICS_QUERY_TIMEOUT_SECONDS must not be negative")
 	}
 
 	if cfg.DatabaseURL == "" {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -5,6 +5,7 @@ go_test(
     srcs = [
         "analytics_cache_test.go",
         "analytics_csv_test.go",
+        "analytics_budget_test.go",
         "analytics_integration_test.go",
         "auth_integration_test.go",
         "clusters_integration_test.go",

--- a/tests/analytics_budget_test.go
+++ b/tests/analytics_budget_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nesono/evidence-store/internal/config"
+	"github.com/nesono/evidence-store/internal/server"
+)
+
+// serverWithBudget builds a server whose analytics queries must finish within
+// the given budget. A nanosecond is unmeetable, which is the point: it exercises
+// the path a genuinely oversized query takes without needing an oversized
+// database to produce one.
+func serverWithBudget(t *testing.T, budget time.Duration) *httptest.Server {
+	t.Helper()
+
+	cfg := &config.Config{
+		DatabaseURL:           testPool.Config().ConnString(),
+		ListenAddr:            ":0",
+		DefaultPageSize:       100,
+		MaxPageSize:           1000,
+		MaxBatchSize:          1000,
+		LogLevel:              "ERROR",
+		AnalyticsQueryTimeout: budget,
+	}
+
+	srv := httptest.NewServer(server.New(cfg, testPool).Handler())
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func getFrom(t *testing.T, srv *httptest.Server, path string) (*http.Response, map[string]any) {
+	t.Helper()
+
+	resp, err := http.Get(srv.URL + path)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	return resp, body
+}
+
+// A query that cannot finish in budget must come back as a refusal with advice,
+// not as a dropped connection after the server's request timeout.
+func TestAnalyticsBudgetRefusesInsteadOfHanging(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	srv := serverWithBudget(t, time.Nanosecond)
+
+	for _, path := range []string{
+		"/api/v1/analytics/tests?repo=" + url.QueryEscape(f.repo),
+		"/api/v1/analytics/summary?repo=" + url.QueryEscape(f.repo),
+		"/api/v1/analytics/clusters?repo=" + url.QueryEscape(f.repo),
+	} {
+		resp, body := getFrom(t, srv, path)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, path)
+		assert.Contains(t, body["error"], "narrow the filter or the time window", path)
+	}
+}
+
+// The advice has to name the budget, or the reader cannot tell whether the
+// query was outrageous or the limit was tight.
+func TestAnalyticsBudgetMessageNamesTheLimit(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	srv := serverWithBudget(t, time.Nanosecond)
+
+	_, body := getFrom(t, srv, "/api/v1/analytics/tests?repo="+url.QueryEscape(f.repo))
+	assert.Contains(t, body["error"], "1ns")
+}
+
+// A budget generous enough for the query must not interfere with it.
+func TestAnalyticsBudgetAllowsQueriesThatFit(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	srv := serverWithBudget(t, 30*time.Second)
+
+	resp, body := getFrom(t, srv, "/api/v1/analytics/tests?repo="+url.QueryEscape(f.repo))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, float64(6), body["total"])
+}
+
+// Zero means "no budget of our own", leaving only the server's request timeout.
+func TestAnalyticsBudgetZeroDisables(t *testing.T) {
+	f := seedAnalyticsFixture(t)
+	srv := serverWithBudget(t, 0)
+
+	resp, body := getFrom(t, srv, "/api/v1/analytics/tests?repo="+url.QueryEscape(f.repo))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, float64(6), body["total"])
+}


### PR DESCRIPTION
Phase 4c of `docs/analytics-plan.md`, for #58. Third of three separate PRs for phase 4, independent of #67 and #68.

Phase 4c was *"a nightly rollup table if the live aggregation is too slow"*. I measured before building, and the measurement said don't build it — while pointing at a different defect that was worth fixing.

## The measurement

6,050,000 rows / 12 repos / 88 procedures / one year (1664 MB table, 3888 MB with indexes):

| window | one repo (605k rows) | all 12 repos (6.05M rows) |
|---|---|---|
| 3 hours | 0.081 s | 0.230 s |
| 24 hours | 0.187 s | 1.260 s |
| 7 days | 0.313 s | 4.562 s |
| 30 days | 0.609 s | 11.107 s |
| 90 days | 1.136 s | 28.423 s |
| 365 days | 1.963 s | **connection dropped at 30 s** |

## No rollup table

Analytics is scoped to a repo — that's how the UI drives it and how the plan designed it. The worst case there is a **full year at 2 seconds**, and with #67 a re-sort of that result is free.

A nightly rollup would buy a second and a half on the rarest query, in exchange for a background worker, a second schema, an invalidation story, and answers stale by up to a day. That's a bad trade. It stays unbuilt, and the plan doc now records why with the numbers.

## The defect that was actually there

The unfiltered year-long query didn't return an error — it ran until the server's 30 s request timeout and the connection was dropped. `http=000`, zero bytes, no status, no body, nothing to act on. Thirty seconds of waiting to learn nothing.

Aggregations now run under a budget (`EVIDENCE_ANALYTICS_QUERY_TIMEOUT_SECONDS`, default 15). Verified against the same 6M-row database that produced the hang:

```
before:  http=000  time=30.001s   (connection dropped, no body)
after:   http=422  time=15.006s   {"error":"query did not finish within 15s;
                                    narrow the filter or the time window"}
```

Same advice the existing size caps give, so the failure modes are consistent. A repo-scoped 24-hour query on the same database is unaffected at 0.205 s.

## Implementation note

The budget is derived from the **request context** rather than held in the store, for two reasons: a caller hanging up is then not mistaken for a query that ran long (the check requires the parent context to still be live), and it touches no store constructor, so this PR doesn't collide with #67.

## Testing

4 integration tests against a server built with a deliberately unmeetable budget — that exercises the refusal path without needing an oversized database to provoke one. They cover all three endpoints, that the message names the limit, that a generous budget doesn't interfere, and that `0` disables it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)