### PR TITLE
Search a branch, tag or commit with one field

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ curl "http://localhost:8000/api/v1/evidence?sort=finished_at&order=desc"
 curl "http://localhost:8000/api/v1/evidence?limit=50&offset=50&include_total=false"
 ```
 
-**Query parameters:** `repo`, `branch`, `rcs_ref`, `evidence_type`, `source`, `procedure_ref`, `result`, `finished_after`, `finished_before`, `tags`, `notes`, `limit`, `cursor`, `offset`, `sort`, `order`, `include_total`, `include_inherited`.
+**Query parameters:** `repo`, `branch`, `rcs_ref`, `ref`, `evidence_type`, `source`, `procedure_ref`, `result`, `finished_after`, `finished_before`, `tags`, `notes`, `limit`, `cursor`, `offset`, `sort`, `order`, `include_total`, `include_inherited`.
 
 ### Pagination and sorting
 
@@ -377,6 +377,8 @@ curl "http://localhost:8000/api/v1/analytics/tests?ref=~^release/"  # regex, bot
 ```
 
 Commits match by prefix, so a pasted short SHA finds the full one it abbreviates. Branches and tags match whole — a prefix there would answer a request for `release/1.1` with `release/1.10` as well. `ref` is available on every endpoint that takes filters, including `/api/v1/evidence`.
+
+It is what both the **Search** and **Analytics** tabs of the web UI put in their filter bar: one **Branch, tag or commit** box rather than separate fields, since a record has exactly one of each and filtering on a combination of them narrowed to nothing. `branch` and `rcs_ref` remain available to API callers who do want to name the column.
 
 The regex engine is [PostgreSQL POSIX regular expressions](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP) (the `~` operator). This supports the POSIX Extended Regular Expression syntax including character classes (`[a-z]`, `[[:digit:]]`), alternation (`a|b`), quantifiers (`*`, `+`, `?`, `{n,m}`), and anchors (`^`, `$`). Matching is case-sensitive.
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "list_offset_sort_test.go",
         "regex_search_test.go",
         "retention_integration_test.go",
+        "search_ref_test.go",
         "utc_normalization_test.go",
     ],
     data = ["//migrations"],

--- a/tests/search_ref_test.go
+++ b/tests/search_ref_test.go
@@ -1,0 +1,98 @@
+package tests
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nesono/evidence-store/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// Tests: combined ref filter on the list endpoint
+//
+// The search UI offers one box for "branch, tag or commit", the same as
+// analytics does, so the list endpoint has to answer that box on its own.
+// ---------------------------------------------------------------------------
+
+// seedSearchRefFixture inserts one record per identity shape and returns the
+// repo they share, so a filter can be checked against a known set.
+func seedSearchRefFixture(t *testing.T) string {
+	t.Helper()
+
+	repo := "org/search_ref_" + uuid.New().String()[:8]
+	records := []model.EvidenceCreate{
+		makeEvidence(repo, "main", "aaaa1111bbbb2222cccc3333dddd4444eeee5555", "//on:main", "ci", model.ResultPass),
+		makeEvidence(repo, "release/1.1", "1111aaaa2222bbbb3333cccc4444dddd5555eeee", "//on:release11", "ci", model.ResultPass),
+		makeEvidence(repo, "release/1.10", "9999aaaa8888bbbb7777cccc6666dddd5555eeee", "//on:release110", "ci", model.ResultPass),
+		makeEvidence(repo, "feature/x", "v2.0.0", "//on:tag", "ci", model.ResultPass),
+	}
+	for _, ev := range records {
+		resp := postJSON(t, "/api/v1/evidence", ev)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp.Body.Close()
+	}
+	return repo
+}
+
+// searchRefProcedures lists the procedures a ref filter selects within a repo.
+func searchRefProcedures(t *testing.T, repo, ref string) []string {
+	t.Helper()
+
+	q := url.Values{"repo": {repo}, "ref": {ref}}
+	resp := getJSON(t, "/api/v1/evidence?"+q.Encode())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	result := decodeJSON[listResponse](t, resp)
+
+	out := make([]string, 0, len(result.Records))
+	for _, r := range result.Records {
+		out = append(out, r.ProcedureRef)
+	}
+	return out
+}
+
+func TestSearchRefMatchesBranch(t *testing.T) {
+	repo := seedSearchRefFixture(t)
+	assert.Equal(t, []string{"//on:main"}, searchRefProcedures(t, repo, "main"))
+}
+
+func TestSearchRefMatchesFullCommit(t *testing.T) {
+	repo := seedSearchRefFixture(t)
+	assert.Equal(t, []string{"//on:main"},
+		searchRefProcedures(t, repo, "aaaa1111bbbb2222cccc3333dddd4444eeee5555"))
+}
+
+// Pasting an abbreviated SHA is the common case and has to find the full one.
+func TestSearchRefMatchesAbbreviatedCommit(t *testing.T) {
+	repo := seedSearchRefFixture(t)
+	assert.Equal(t, []string{"//on:main"}, searchRefProcedures(t, repo, "aaaa111"))
+}
+
+func TestSearchRefMatchesTagStoredAsRef(t *testing.T) {
+	repo := seedSearchRefFixture(t)
+	assert.Equal(t, []string{"//on:tag"}, searchRefProcedures(t, repo, "v2.0.0"))
+}
+
+// Branches are matched whole. Prefix matching there would answer a request for
+// release/1.1 with release/1.10 as well.
+func TestSearchRefDoesNotPrefixMatchBranches(t *testing.T) {
+	repo := seedSearchRefFixture(t)
+	assert.Equal(t, []string{"//on:release11"}, searchRefProcedures(t, repo, "release/1.1"))
+}
+
+// The single box replaces two regex-capable fields, so it has to stay
+// regex-capable itself — against both identity columns.
+func TestSearchRefAcceptsRegex(t *testing.T) {
+	repo := seedSearchRefFixture(t)
+	assert.ElementsMatch(t,
+		[]string{"//on:release11", "//on:release110"},
+		searchRefProcedures(t, repo, "~^release/"))
+
+	assert.ElementsMatch(t,
+		[]string{"//on:tag"},
+		searchRefProcedures(t, repo, "~^v2\\."))
+}

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -7,6 +7,8 @@ go_library(
         "static/app.js",
         "static/index.html",
         "static/style.css",
+        "static/analytics.js",
+        "static/common.js",
     ],
     importpath = "github.com/nesono/evidence-store/web",
     visibility = ["//visibility:public"],

--- a/web/static/analytics.js
+++ b/web/static/analytics.js
@@ -380,6 +380,9 @@ async function loadTests() {
         procedure_ref: tr.dataset.procedure,
       });
       const filters = readFilters();
+      // Search takes the same `ref` box, so the branch, tag or commit the
+      // numbers were computed over carries across instead of being dropped.
+      if (filters.ref) params.set("ref", filters.ref);
       if (filters.finished_after) params.set("finished_after", filters.finished_after);
       if (filters.finished_before) params.set("finished_before", filters.finished_before);
       window.location.search = params.toString();

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -12,8 +12,11 @@ import {
 import { showAnalytics } from "./analytics.js";
 
 // Fields shown in the collapsed bar; everything else lives behind "More filters".
-const BAR_TEXT_FIELDS = ["repo", "rcs_ref"];
-const ADVANCED_TEXT_FIELDS = ["branch", "evidence_type", "source", "procedure_ref", "tags", "notes"];
+// `ref` is one box matching a branch, a tag or a commit, the same as analytics
+// offers — a record has exactly one of each, so filtering on a combination of
+// them only ever narrowed to nothing.
+const BAR_TEXT_FIELDS = ["repo", "ref"];
+const ADVANCED_TEXT_FIELDS = ["evidence_type", "source", "procedure_ref", "tags", "notes"];
 const TEXT_FIELDS = [...BAR_TEXT_FIELDS, ...ADVANCED_TEXT_FIELDS];
 const DATETIME_FIELDS = ["finished_after", "finished_before"];
 // Badged onto the toggle, so a collapsed panel never hides an applied constraint.
@@ -66,6 +69,17 @@ function readStateFromURL() {
   }
   if (params.has("result")) filters.result = params.get("result");
   if (params.has("include_inherited")) filters.include_inherited = params.get("include_inherited");
+
+  // Links made before the two identity fields became one still carry `branch`
+  // or `rcs_ref`. Both are still valid API filters, but the form no longer has
+  // a box for either, and a filter with nowhere to show is a filter the user
+  // cannot see or clear — so they are folded into `ref`, which matches either
+  // column. A link carrying both keeps the commit, as the more specific of the
+  // two.
+  if (!filters.ref) {
+    const legacy = params.get("rcs_ref") || params.get("branch");
+    if (legacy) filters.ref = legacy;
+  }
 
   const offset = parseInt(params.get("offset"), 10);
   windowOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -100,8 +100,12 @@
                     <label class="fb-field fb-field-repo">Repo
                         <input type="text" name="repo" placeholder="org/repo or ~^org/.*" list="repos-list">
                     </label>
-                    <label class="fb-field fb-field-commit">Commit
-                        <input type="text" name="rcs_ref" placeholder="abc123...">
+                    <!-- One box for all three identities. A user pasting what they are
+                         looking at should not have to say first whether it is a branch,
+                         a tag or a commit, and combining them never made sense: a record
+                         has exactly one of each. -->
+                    <label class="fb-field fb-field-ref">Branch, tag or commit
+                        <input type="text" name="ref" placeholder="main, v2.0.0, abc123 or ~^release/">
                     </label>
                     <!-- A checkbox dropdown. There is no native HTML control for this:
                          <select multiple> renders as an always-expanded list box, not a
@@ -129,12 +133,11 @@
                 <div id="filter-advanced" hidden>
                     <small class="regex-hint">Prefix with <code>~</code> for regex, e.g. <code>~^org/.*</code></small>
                     <div class="grid">
-                        <label>Branch <input type="text" name="branch" placeholder="main or ~^release/.*"></label>
                         <label>Evidence type <input type="text" name="evidence_type" placeholder="bazel or ~^(bazel|manual)$" list="evidence-types-list"></label>
                         <label>Source <input type="text" name="source" placeholder="CI URL or user" list="sources-list"></label>
+                        <label>Procedure <input type="text" name="procedure_ref" placeholder="//pkg:target or ~//pkg/.*"></label>
                     </div>
                     <div class="grid">
-                        <label>Procedure <input type="text" name="procedure_ref" placeholder="//pkg:target or ~//pkg/.*"></label>
                         <label>After <small>(UTC)</small>
                             <input type="text" name="finished_after" placeholder="2026-01-01 00:00 (UTC)" data-utc-preview>
                             <small class="utc-preview" data-preview-for="finished_after"></small>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -138,22 +138,28 @@ body > main {
     margin-bottom: 0;
 }
 
-/* Both inputs are sized in `ch`, the width of the element's own "0" glyph, so
-   the monospace commit field holds exactly a 40-character hash. Repo is
-   proportional, so its 40ch renders a little narrower. Neither grows: both hold
-   identifiers of bounded length. Longer values (full hashes, or `~` regex
-   filters — which is why there is no maxlength) scroll.
+/* Both inputs are sized in `ch`, the width of the element's own "0" glyph.
+   The ref box gets the 40 a commit hash needs; repo gets fewer, because
+   `org/repo` is short and the two boxes plus the ref field's spelt-out label no
+   longer fit on one line at equal widths — and a wrapped bar costs more than the
+   tail of a long repo name does. Neither grows: both hold identifiers of bounded
+   length. Longer values (or `~` regex filters — which is why there is no
+   maxlength) scroll.
 
    The padding and border are added back explicitly, because under Pico's global
    border-box a plain 40ch would be consumed by them and leave about 38
    characters visible. Doing it this way rather than with content-box keeps
    box-sizing consistent, so the shared height below means the height it says. */
-#filter-bar .fb-field-repo input,
-#filter-bar .fb-field-commit input {
+#filter-bar .fb-field input {
     flex: 0 0 auto;
-    width: calc(40ch
+    --fb-input-chars: 40;
+    width: calc(var(--fb-input-chars) * 1ch
         + 2 * var(--pico-form-element-spacing-horizontal)
         + 2 * var(--pico-border-width));
+}
+
+#filter-bar .fb-field-repo input {
+    --fb-input-chars: 20;
 }
 
 /* Every control in the bar shares one height, so they sit on a common baseline
@@ -161,10 +167,6 @@ body > main {
 #filter-bar .fb-field input,
 #filter-bar .fb-dropdown > summary {
     height: var(--fb-control-height);
-}
-
-#filter-bar .fb-field-commit input {
-    font-family: monospace;
 }
 
 #filter-bar .fb-field {


### PR DESCRIPTION
Closes #66.

Search offered two identity boxes: **Commit** in the bar and **Branch** behind *More filters*. A record has exactly one of each, so filling both only ever narrowed to nothing, and keeping them apart meant the branch filter was the one you had to go looking for.

Both are replaced by the `ref` box the Analytics tab already uses — one **Branch, tag or commit** field that matches a value against either identity column: whole for branches and tags, by prefix for commits (so a pasted short SHA finds the full one), and as a POSIX regex behind `~`.

### No API change

`ref` has been parsed for every filtered endpoint since the shared filter parser landed (#62), `/api/v1/evidence` included — it just had no box in the search UI. This is the UI catching up. `branch` and `rcs_ref` remain available to API callers who want to name the column.

Old links carrying `branch=` or `rcs_ref=` fold into the one box (commit wins if both are present) rather than applying a filter the form has nowhere to show or clear.

Drilling from an Analytics row into Search now carries the ref along, since both sides finally speak the same filter.

### Tests

`tests/search_ref_test.go` pins the behaviour to the **list** endpoint, which previously only had coverage through the analytics ones: branch, full SHA, abbreviated SHA, tag, regex over both columns, and that `release/1.1` does not also return `release/1.10`.

### Also here

`bazel run //:gazelle` found a pre-existing gap while picking up the new test file: `web/BUILD.bazel` was missing `static/analytics.js` and `static/common.js` from `embedsrcs`, so a Bazel-built binary served an index page whose JS 404s. Fixed in the same commit.

### Verification

Full `go test ./...` passes. Also ran the server against a local Postgres and drove the page in headless Chrome — regex, tag, abbreviated-SHA and legacy-link cases all return the right rows — and compared the filter bar against `main` at 1200/1400/1800px to confirm the longer label does not change where the bar wraps (repo is narrowed to 20ch to pay for it).

The **Add Result** form keeps its separate Branch and Commit inputs: writing a record needs both named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)